### PR TITLE
[test-coverage] decouple client methods, reorder a few methods for easier

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -88,6 +88,10 @@ module Sensu
       @handler_queue.pop(&handle)
     end
 
+    def handle_event(event)
+      @handler_queue.push(event)
+    end
+
     def setup_results
       @amq.queue('results').subscribe do |result_json|
         result = JSON.parse(result_json)
@@ -124,10 +128,6 @@ module Sensu
           end
         end
       end
-    end
-
-    def handle_event(event)
-      @handler_queue.push(event)
     end
 
     def setup_publisher

--- a/test/sensu_server_and_client_test.rb
+++ b/test/sensu_server_and_client_test.rb
@@ -67,7 +67,7 @@ class TestSensu < MiniTest::Unit::TestCase
     end
   end
 
-  def test_checks
+  def test_execute_checks
     server = Sensu::Server.new(@options)
     client = Sensu::Client.new(@options)
     server.setup_logging
@@ -78,7 +78,6 @@ class TestSensu < MiniTest::Unit::TestCase
     server.setup_results
     client.setup_amqp
     client.setup_keep_alives
-    client.setup_subscriptions
     @settings['checks'].each_key do |check_name|
       client.execute_check({'name' => check_name})
     end


### PR DESCRIPTION
[test-coverage] decouple client methods, reorder a few methods for easier reading
