### PR TITLE
[rabbitmq-failure] unsubscribe doesn't reap dead consumers, ack messages, etc

### DIFF
--- a/lib/sensu/client.rb
+++ b/lib/sensu/client.rb
@@ -76,8 +76,7 @@ module Sensu
       end
       EM.add_periodic_timer(0.5) do
         unless uniq_queue.subscribed?
-          uniq_queue.unsubscribe
-          uniq_queue.subscribe do |check_json|
+          uniq_queue.subscribe(:ack => true) do |check_json|
             check = JSON.parse(check_json)
             execute_check(check)
           end

--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -51,8 +51,7 @@ module Sensu
       keepalive_queue = @amq.queue('keepalives')
       EM.add_periodic_timer(0.5) do
         unless keepalive_queue.subscribed?
-          keepalive_queue.unsubscribe
-          keepalive_queue.subscribe do |keepalive_json|
+          keepalive_queue.subscribe(:ack => true) do |keepalive_json|
             client = JSON.parse(keepalive_json)['name']
             @redis.set('client:' + client, keepalive_json).callback do
               @redis.sadd('clients', client)
@@ -135,8 +134,7 @@ module Sensu
       result_queue = @amq.queue('results')
       EM.add_periodic_timer(0.5) do
         unless result_queue.subscribed?
-          result_queue.unsubscribe
-          result_queue.subscribe do |result_json|
+          result_queue.subscribe(:ack => true) do |result_json|
             result = JSON.parse(result_json)
             process_result(result)
           end


### PR DESCRIPTION
[rabbitmq-failure] unsubscribe doesn't reap dead consumers, ack messages, third rabbitmq failure still results in disconnected clients
