### PR TITLE
[stdin] no longer creating event files, handlers read from STDIN

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sensu (0.5.12)
+    sensu (0.5.13)
       amqp (= 0.7.4)
       async_sinatra
       em-hiredis

--- a/lib/sensu/config.rb
+++ b/lib/sensu/config.rb
@@ -58,19 +58,5 @@ module Sensu
       optparse.parse!(arguments)
       options
     end
-
-    def create_working_directory
-      begin
-        Dir.mkdir('/tmp/sensu')
-      rescue SystemCallError
-      end
-    end
-
-    def purge_working_directory
-      Dir.foreach('/tmp/sensu') do |file|
-        next if file == '.' || file == '..'
-        File.delete('/tmp/sensu/' + file)
-      end
-    end
   end
 end

--- a/test/handler.rb
+++ b/test/handler.rb
@@ -1,31 +1,10 @@
 #!/usr/bin/env ruby
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
-require 'optparse'
 require 'json'
 
-options = {}
+event = JSON.parse(STDIN.read)
 
-optparse = OptionParser.new do |opts|
-  opts.on('-h', '--help', 'Display this screen') do
-    puts opts
-    exit
-  end
-
-  opts.on('-f', '--file FILE', 'Event file') do |file|
-    options[:file] = file
-  end
-end
-
-optparse.parse!
-
-unless options[:file]
-  puts "You must supply an event file"
-  exit
-end
-
-event = JSON.parse(File.open(options[:file], 'r').read)
-
-File.open('/tmp/sensu/test_handlers', 'w') do |file|
+File.open('/tmp/sensu_test_handlers', 'w') do |file|
   file.write(JSON.pretty_generate(event))
 end

--- a/test/sensu_server_and_client_test.rb
+++ b/test/sensu_server_and_client_test.rb
@@ -14,8 +14,6 @@ class TestSensu < MiniTest::Unit::TestCase
   def setup
     @options = {:config_file => File.join(File.dirname(__FILE__), 'config.json')}
     config = Sensu::Config.new(@options)
-    config.create_working_directory
-    config.purge_working_directory
     @settings = config.settings
   end
 
@@ -28,12 +26,6 @@ class TestSensu < MiniTest::Unit::TestCase
   def test_cli_arguments
     options = Sensu::Config.read_arguments(['-w', '-c', @options[:config_file]])
     eventually({:worker => true, :config_file => @options[:config_file]}) { options }
-  end
-
-  def test_create_working_directory
-    config = Sensu::Config.new(@options)
-    config.create_working_directory
-    eventually(true) { File.exists?('/tmp/sensu') }
   end
 
   def test_keepalives
@@ -72,7 +64,7 @@ class TestSensu < MiniTest::Unit::TestCase
     }
     server.handle_event(event)
     eventually(true, :total => 1.5) do
-      JSON.parse(File.open('/tmp/sensu/test_handlers', 'rb').read) == event
+      JSON.parse(File.open('/tmp/sensu_test_handlers', 'rb').read) == event
     end
   end
 


### PR DESCRIPTION
[stdin] no longer creating event files, handlers read from STDIN, use blocking popen in defer for cross platform support :/
