### PR TITLE
[logging] use a logging format, split handler output into separate log lines for easy reading

### DIFF
--- a/test/handler.rb
+++ b/test/handler.rb
@@ -5,6 +5,9 @@ require 'json'
 
 event = JSON.parse(STDIN.read)
 
+puts 'name="Test Logging" event_id=handler:default reason="This should be first"'
+puts 'name="Test Logging" event_id=handler:default reason="This should be second"'
+
 File.open('/tmp/sensu_test_handlers', 'w') do |file|
   file.write(JSON.pretty_generate(event))
 end


### PR DESCRIPTION
[logging] http://docs.splunk.com/Documentation/Splunk/latest/Knowledge/UnderstandandusetheCommonInformationModel
