### PR TITLE
[0.8.19-fixes] eliminate duplicate subscriptions

### DIFF
--- a/lib/sensu/client.rb
+++ b/lib/sensu/client.rb
@@ -115,7 +115,7 @@ module Sensu
     def setup_subscriptions
       @logger.debug('[subscribe] -- setup subscriptions')
       @check_queue = @amq.queue(String.unique, :exclusive => true)
-      @settings.client.subscriptions.push('uchiwa')
+      @settings.client.subscriptions.push('uchiwa').uniq!
       @settings.client.subscriptions.each do |exchange|
         @logger.debug('[subscribe] -- queue binding to exchange -- ' + exchange)
         @check_queue.bind(@amq.fanout(exchange))


### PR DESCRIPTION
- noticed more than one "uchiwa" subscription after reconnecting to rabbitmq
