### PR TITLE
[increased-logging] Add result status (exit code) and check output to

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -175,7 +175,7 @@ module Sensu
       @result_queue = @amq.queue('results')
       @result_queue.subscribe do |result_json|
         result = Hashie::Mash.new(JSON.parse(result_json))
-        @logger.info('[result] -- received result -- ' + result.client + ' -- ' + result.check.name)
+        @logger.info('[result] -- received result -- ' + [result.check.name, result.client, result.check.status, result.check.output].join(' -- '))
         process_result(result)
       end
     end


### PR DESCRIPTION
logging

This just add's the exit code and the check output into the log to make debugging issues and finding out whats wrong/right with your checks easier.
