### PR TITLE
Keep deep merges on Arrays flat 

### DIFF
--- a/lib/sensu/patches/ruby.rb
+++ b/lib/sensu/patches/ruby.rb
@@ -39,6 +39,7 @@ class Hash
         value1.concat(value2).uniq
       else
         value2
+      end
     end
     self.merge(hash, &merger)
   end


### PR DESCRIPTION
This allows the following config:
# file1.json

"foo": {
  "bar": ["one"]
}
# file2.json

"foo": {
 "bar": ["two"]
}

This gives us merged "bar": ["one","two"] as opposed to "bar": [["one"],["two"]]
