### PR TITLE
Upgrade vagrant config for Vagrant >0.9 (extend / cleanup commits for Issue 218)

### DIFF
--- a/dist/chef/Vagrantfile
+++ b/dist/chef/Vagrantfile
@@ -3,8 +3,11 @@ Vagrant::Config.run do |config|
   config.vm.box = "ubuntu-1104-server-i386"
   # `vagrant box add centos-57-x86-64 http://dl.dropbox.com/u/8072848/centos-5.7-x86_64.box`
   #config.vm.box = "centos-57-x86-64"
-  config.vm.customize ["modifyvm", :id, "--memory", "1024"]
-  config.vm.customize ["modifyvm", :id, "--name",   "Sensu Stack"]
+  config.vm.customize [
+    "modifyvm", :id,
+    "--name",   "Sensu Stack",
+    "--memory", "1024"
+  ]
 
   config.vm.provision :shell, :inline => "echo 'nameserver 8.8.8.8' > /etc/resolv.conf"
   config.vm.provision :shell, :inline => "gem install chef --no-rdoc --no-ri"

--- a/dist/puppet/Vagrantfile
+++ b/dist/puppet/Vagrantfile
@@ -1,7 +1,10 @@
 Vagrant::Config.run do |config|
   config.vm.box = "ubuntu-1104-server-i386"
-  config.vm.customize ["modifyvm", :id, "--memory", "1024"]
-  config.vm.customize ["modifyvm", :id, "--name",   "Sensu Stack"]
+  config.vm.customize [
+    "modifyvm", :id,
+    "--name",   "Sensu Stack",
+    "--memory", "1024"
+  ]
 
   config.vm.provision :shell, :inline => "echo 'nameserver 8.8.8.8' > /etc/resolv.conf"
   config.vm.provision :shell, :inline => "gem install puppet --no-ri --no-rdoc"


### PR DESCRIPTION
As already stated in issue #218 the settings for `vm.customize` and `vm.forward_port` changed from Vagrant 0.8 to Vagrant 0.9 (http://vagrantup.com/docs/changes/changes_08x_09x.html).

The patch fixes the VM settings for both the Chef and Puppet `Vagrantfile`. It does not affect any functional changes on the VM.

Tested with Vagrant 0.9.3 + Vagrant 0.9.4.

Important: This patch makes the settings incompatible with vagrant < 0.9!
