### PR TITLE
Check output should properly escape newlines

### DIFF
--- a/lib/sensu/client.rb
+++ b/lib/sensu/client.rb
@@ -239,7 +239,7 @@ module Sensu
           check.status ||= 0
           check_output = check.output.chomp.gsub(/\n/, '\n')
           if validates && check.status.is_a?(Integer)
-            @logger.info('[socket] -- publishing check result -- ' + [check.name, check.status, check.output.chomp.gsub].join(' -- '))
+            @logger.info('[socket] -- publishing check result -- ' + [check.name, check.status, check_output].join(' -- '))
             @amq.queue('results').publish({
               :client => @settings.client.name,
               :check => check.to_hash


### PR DESCRIPTION
So the json isn't fucked, log output is on the same line, etc.
