### PR TITLE
Update MIT license link with new org

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,4 +9,4 @@
 ** Documentation
   Please refer to the [[https://github.com/sensu/sensu/wiki][Sensu Wiki]].
 ** License
-  Sensu is released under the [[https://github.com/sonian/sensu/blob/master/MIT-LICENSE.txt][MIT license]].
+  Sensu is released under the [[https://github.com/sensu/sensu/blob/master/MIT-LICENSE.txt][MIT license]].


### PR DESCRIPTION
This is a small fix so the MIT license link works with the new organization changes.
