### PR TITLE
Log handling events at debug level.

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -158,7 +158,7 @@ module Sensu
       unless check_subdued?(event[:check], :handler)
         handlers = check_handlers(event[:check])
         handlers.each do |handler|
-          @logger.info('handling event', {
+          @logger.debug('handling event', {
             :event => event,
             :handler => handler
           })


### PR DESCRIPTION
Making info less verbose. When used for metric collection this generates ridiculous amounts of log.
