### PR TITLE
Do not set stash if unparseable, remove stash if unparseable

### DIFF
--- a/lib/sensu/api.rb
+++ b/lib/sensu/api.rb
@@ -325,17 +325,15 @@ module Sensu
     apost %r{/stash(?:es)?/(.*)} do |path|
       begin
         post_body = JSON.parse(request.body.read)
-      rescue JSON::ParserError
-        status 400
-        body ''
-      end
-      unless status == 400
         $redis.set('stash:' + path, post_body.to_json).callback do
           $redis.sadd('stashes', path).callback do
             status 201
             body ''
           end
         end
+      rescue JSON::ParserError
+        status 400
+        body ''
       end
     end
 


### PR DESCRIPTION
Due to stashes being set even if the JSON could not be parsed its possible for a stash to contain unparseable data and cause the API server to fail and fail to return the stashes you requested.

Now if a stash does not contain valid json its removed from the stashes array and the stash itself is removed.
