### PR TITLE
Write to stdout synchronously.

### DIFF
--- a/bin/sensu-api
+++ b/bin/sensu-api
@@ -4,6 +4,8 @@ unless $:.include?(File.dirname(__FILE__) + '/../lib/')
   $: << File.dirname(__FILE__) + '/../lib'
 end
 
+$stdout.sync = true
+
 require 'sensu/api'
 
 options = Sensu::CLI.read

--- a/bin/sensu-client
+++ b/bin/sensu-client
@@ -4,6 +4,8 @@ unless $:.include?(File.dirname(__FILE__) + '/../lib/')
   $: << File.dirname(__FILE__) + '/../lib'
 end
 
+$stdout.sync = true
+
 require 'sensu/client'
 
 options = Sensu::CLI.read

--- a/bin/sensu-server
+++ b/bin/sensu-server
@@ -4,6 +4,8 @@ unless $:.include?(File.dirname(__FILE__) + '/../lib/')
   $: << File.dirname(__FILE__) + '/../lib'
 end
 
+$stdout.sync = true
+
 require 'sensu/server'
 
 options = Sensu::CLI.read

--- a/lib/sensu/logger.rb
+++ b/lib/sensu/logger.rb
@@ -2,6 +2,7 @@ module Sensu
   class Logger
     def initialize(options={})
       @logger = Cabin::Channel.get
+      STDOUT.sync = true
       @logger.subscribe(STDOUT)
       @logger.level = options[:verbose] ? :debug : options[:log_level] || :info
       @log_file = options[:log_file]


### PR DESCRIPTION
Since stdout is used as a logger it should be written synchronously. Otherwise messages are held in buffer and it can be difficult to tell what's going on when there isn't enough volume to force a flush.
