### PR TITLE
AMQP skipped heartbeat handler and logging fixes

### DIFF
--- a/lib/sensu/api.rb
+++ b/lib/sensu/api.rb
@@ -18,7 +18,7 @@ module Sensu
       end
 
       def bootstrap(options={})
-        $logger = Cabin::Channel.get
+        $logger = Sensu::Logger.get
         base = Sensu::Base.new(options)
         $settings = base.settings
         if $settings[:api][:user] && $settings[:api][:password]
@@ -62,12 +62,13 @@ module Sensu
           exit 2
         end
         $rabbitmq = AMQP.connect($settings[:rabbitmq], :on_tcp_connection_failure => connection_failure)
+        $rabbitmq.logger = Sensu::NullLogger.get
         $rabbitmq.on_tcp_connection_loss do |connection, settings|
           $logger.warn('reconnecting to rabbitmq')
           connection.reconnect(false, 10)
         end
         $rabbitmq.on_skipped_heartbeats do
-          $logger.warn('skipped rabbitmq connection heartbeat')
+          $logger.warn('skipped rabbitmq heartbeat')
         end
         $amq = AMQP::Channel.new($rabbitmq)
         $amq.auto_recovery = true

--- a/lib/sensu/base.rb
+++ b/lib/sensu/base.rb
@@ -2,11 +2,9 @@ require 'rubygems'
 
 gem 'eventmachine', '1.0.0.rc.4'
 
-require 'optparse'
 require 'json'
 require 'time'
 require 'uri'
-require 'cabin'
 require 'amqp'
 
 require File.join(File.dirname(__FILE__), 'patches', 'ruby')
@@ -29,8 +27,9 @@ module Sensu
     end
 
     def setup_logging
-      logger = Sensu::Logger.new(@options)
-      logger.reopen
+      logger = Sensu::Logger.new
+      logger.level = @options[:verbose] ? :debug : @options[:log_level] || :info
+      logger.reopen(@options[:log_file])
       logger.setup_traps
     end
 

--- a/lib/sensu/cli.rb
+++ b/lib/sensu/cli.rb
@@ -1,3 +1,5 @@
+require 'optparse'
+
 module Sensu
   class CLI
     def self.read(arguments=ARGV)

--- a/lib/sensu/client.rb
+++ b/lib/sensu/client.rb
@@ -12,7 +12,7 @@ module Sensu
     end
 
     def initialize(options={})
-      @logger = Cabin::Channel.get
+      @logger = Sensu::Logger.get
       base = Sensu::Base.new(options)
       @settings = base.settings
       @timers = Array.new
@@ -31,13 +31,14 @@ module Sensu
         exit 2
       end
       @rabbitmq = AMQP.connect(@settings[:rabbitmq], :on_tcp_connection_failure => connection_failure)
+      @rabbitmq.logger = Sensu::NullLogger.get
       @rabbitmq.on_tcp_connection_loss do |connection, settings|
         @logger.warn('reconnecting to rabbitmq')
         connection.reconnect(false, 10)
       end
       @rabbitmq.on_skipped_heartbeats do
-        @logger.warn('skipped rabbitmq connection heartbeat')
-        @logger.warn('rabbitmq connection heartbeats are not recommended')
+        @logger.warn('skipped rabbitmq heartbeat')
+        @logger.warn('rabbitmq heartbeats are not recommended for clients')
       end
       @amq = AMQP::Channel.new(@rabbitmq)
       @amq.auto_recovery = true

--- a/lib/sensu/process.rb
+++ b/lib/sensu/process.rb
@@ -1,7 +1,7 @@
 module Sensu
   class Process
     def initialize
-      @logger = Cabin::Channel.get
+      @logger = Sensu::Logger.get
     end
 
     def write_pid(file)

--- a/lib/sensu/redis.rb
+++ b/lib/sensu/redis.rb
@@ -8,7 +8,7 @@ module Sensu
 
     def initialize(*arguments)
       super
-      @logger = Cabin::Channel.get
+      @logger = Sensu::Logger.get
       @settings = Hash.new
       @connection_established = false
       @connected = false

--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -14,7 +14,7 @@ module Sensu
     end
 
     def initialize(options={})
-      @logger = Cabin::Channel.get
+      @logger = Sensu::Logger.get
       base = Sensu::Base.new(options)
       @settings = base.settings
       @timers = Array.new
@@ -59,6 +59,7 @@ module Sensu
         exit 2
       end
       @rabbitmq = AMQP.connect(@settings[:rabbitmq], :on_tcp_connection_failure => connection_failure)
+      @rabbitmq.logger = Sensu::NullLogger.get
       @rabbitmq.on_tcp_connection_loss do |connection, settings|
         @logger.warn('reconnecting to rabbitmq')
         resign_as_master do
@@ -66,7 +67,7 @@ module Sensu
         end
       end
       @rabbitmq.on_skipped_heartbeats do
-        @logger.warn('skipped rabbitmq connection heartbeat')
+        @logger.warn('skipped rabbitmq heartbeat')
       end
       @amq = AMQP::Channel.new(@rabbitmq)
       @amq.auto_recovery = true

--- a/lib/sensu/settings.rb
+++ b/lib/sensu/settings.rb
@@ -3,7 +3,7 @@ module Sensu
     attr_reader :indifferent_access, :loaded_env, :loaded_files
 
     def initialize
-      @logger = Cabin::Channel.get
+      @logger = Sensu::Logger.get
       @settings = Hash.new
       [:checks, :handlers, :mutators].each do |key|
         @settings[key] = Hash.new


### PR DESCRIPTION
This PR adds a callback for skipped AMQP heartbeats, and recommends that they should not be used for clients. The AMQP/AMQ-Client libraries do some logging, unfortunately it seems impossible to wrangle it, so I add a null logger to suppress the noise until a patch is pushed upstream.
