### PR TITLE
[amqp] catch channel-level errors when publishing events to exchanges

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -76,6 +76,15 @@ module Sensu
       end
       @amq = AMQP::Channel.new(@rabbitmq)
       @amq.auto_recovery = true
+      @amq.on_error do |channel, channel_close|
+        @logger.fatal('rabbitmq channel closed', {
+          :error => {
+            :reply_code => channel_close.reply_code,
+            :reply_text => channel_close.reply_text
+          }
+        })
+        stop
+      end
     end
 
     def setup_keepalives


### PR DESCRIPTION
There have been a few cases where miss-configured AMQP handlers have caused the AMQP channel to be closed w/o triggering an auto-recovery action, in fact the library doesn't make a peep. This change will make it much easier to identify this issue.
