### PR TITLE
Fix for redis version check

### DIFF
--- a/lib/sensu/redis.rb
+++ b/lib/sensu/redis.rb
@@ -39,7 +39,7 @@ module Sensu
         end
       end
       info.callback do |reply|
-        redis_version = reply.split(/\n/).first.split(/:/).last.chomp
+        redis_version = reply.split(/\n/).select { |v| v =~ /^redis_version/ }.first.split(/:/).last.chomp
         if redis_version < '1.3.14'
           @logger.fatal('redis version must be >= 2.0 RC 1')
           close_connection


### PR DESCRIPTION
redis INFO format has changed in 2.6. Don't assume version string is on first line of output.

See https://gist.github.com/4034477 for INFO output
