### PR TITLE
[API] make DELETE "/clients/#{id}" idempotent

### DIFF
--- a/test/api_tests.rb
+++ b/test/api_tests.rb
@@ -182,7 +182,7 @@ class TestSensuAPI < TestCase
   def test_delete_nonexistent_client
     Sensu::API.run_test(@options) do
       api_request('/client/nonexistent', :delete) do |http, body|
-        assert_equal(404, http.response_header.status)
+        assert_equal(202, http.response_header.status)
         done
       end
     end


### PR DESCRIPTION
Not a solution, but related to https://github.com/sensu/sensu/pull/430. With mysteriously missing redis keys, `DELETE /clients/b33f` will not actually remove a client from the clients set, clear the history, or delete events. It seems a `DELETE` request ought to be idempotent and result in a clean state with or without the existence of a client key
