### PR TITLE
A filter attribute value can be an expression to be eval'd

### DIFF
--- a/lib/sensu/sandbox.rb
+++ b/lib/sensu/sandbox.rb
@@ -1,0 +1,11 @@
+module Sensu
+  module Sandbox
+    def self.eval(expression, value=nil)
+      result = Proc.new do
+        $SAFE = 4
+        Kernel.eval(expression)
+      end
+      result.call
+    end
+  end
+end

--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -57,19 +57,5 @@ module Sensu
         diff
       end
     end
-
-    def hash_values_equal?(hash_one, hash_two)
-      hash_one.keys.all? do |key|
-        if hash_one[key] == hash_two[key]
-          true
-        else
-          if hash_one[key].is_a?(Hash) && hash_two[key].is_a?(Hash)
-            hash_values_equal?(hash_one[key], hash_two[key])
-          else
-            false
-          end
-        end
-      end
-    end
   end
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -122,6 +122,23 @@ describe 'Sensu::Server' do
     @server.check_subdued?(check, :handler).should be_false
   end
 
+  it 'can determine if filter attributes match an event' do
+    attributes = {
+      :occurrences => 1
+    }
+    event = event_template
+    @server.filter_attributes_match?(attributes, event).should be_true
+    event[:occurrences] = 2
+    @server.filter_attributes_match?(attributes, event).should be_false
+    attributes[:occurrences] = "eval: value == 1 || value % 60 == 0"
+    event[:occurrences] = 1
+    @server.filter_attributes_match?(attributes, event).should be_true
+    event[:occurrences] = 2
+    @server.filter_attributes_match?(attributes, event).should be_false
+    event[:occurrences] = 120
+    @server.filter_attributes_match?(attributes, event).should be_true
+  end
+
   it 'can determine if a event is to be filtered' do
     event = event_template
     event[:client][:environment] = 'production'


### PR DESCRIPTION
This enables filters to use attribute values like "value == 1 || value % 60 ==0", where "value" is a local variable already set in the eval() sandbox.
