### PR TITLE
Make base.settings available to extensions

### DIFF
--- a/lib/sensu/base.rb
+++ b/lib/sensu/base.rb
@@ -43,7 +43,7 @@ module Sensu
     end
 
     def extensions
-      extensions = Extensions.new
+      extensions = Extensions.new(settings)
       if @options[:extension_dir]
         extensions.require_directory(@options[:extension_dir])
       end

--- a/lib/sensu/extensions.rb
+++ b/lib/sensu/extensions.rb
@@ -1,6 +1,7 @@
 module Sensu
   class Extensions
-    def initialize
+    def initialize(settings)
+      @settings = settings
       @logger = Logger.get
       @extensions = Hash.new
       EXTENSION_CATEGORIES.each do |category|
@@ -40,6 +41,7 @@ module Sensu
         extension_type = category.to_s.chop
         Extension.const_get(extension_type.capitalize).descendants.each do |klass|
           extension = klass.new
+          extension.settings = @settings
           @extensions[category][extension.name] = extension
           loaded(extension_type, extension.name, extension.description)
         end
@@ -59,6 +61,8 @@ module Sensu
 
   module Extension
     class Base
+      attr_accessor :settings
+      
       def name
         'base'
       end


### PR DESCRIPTION
Commented on issue https://github.com/sensu/sensu/issues/425 and am trying this for getting access to settings in extensions for a similar coding model to sensu-plugins.
