### PR TITLE
Allow use of heartbeat option to rabbitmq connect

### DIFF
--- a/lib/sensu/rabbitmq.rb
+++ b/lib/sensu/rabbitmq.rb
@@ -27,9 +27,6 @@ module Sensu
     end
 
     def connect(options={})
-      options.reject! do |key, value|
-        key == :heartbeat
-      end
       on_failure = Proc.new do
         error = RabbitMQError.new('cannot connect to rabbitmq')
         @on_error.call(error)


### PR DESCRIPTION
The default value for the heartbeat option is 0, or disabled. Therefore the
functionality of Sensu will remain unchanged by default. We should provide
users the freedom to weigh the advantages and disadvantages of setting this
option.
