### PR TITLE
Fix for sensu server zombies after upgrade to 0.9.9

### DIFF
--- a/lib/sensu/io.rb
+++ b/lib/sensu/io.rb
@@ -37,6 +37,10 @@ module Sensu
           kill_process_group(child.pid)
           wait_on_process_group(child.pid)
           ['Execution timed out', 2]
+        rescue => e
+          kill_process_group(child.pid)
+          wait_on_process_group(child.pid)
+          ["Exception during execution command '#{command}': #{e} \n #{e.backtrace}", 2]
         end
       end
 


### PR DESCRIPTION
Hi,
  after upgrade to sensu 0.9.9 sensu-server was genereating tons of zomobies and it was causing crash of whole system due to lack of memory leading to swapping and oom-killer events, etc... 
  It's necessary to handle all exceptions when running subprocesses, not only Timeout:Error. It's necessary to kill and wait to process in any case to prevent zombies. Handlers can be third party scripts or path can with error, so you can't expect any exact behavior in this part.  

How to replicate:
register and use not exisitng handler (bad path) or handler that does not open STDIN, run sensu-server and `watch 'ps axu | grep Z'`

Best wishes
Adam
