### PR TITLE
Lock sinatra to version 1.3.5

### DIFF
--- a/lib/sensu/api.rb
+++ b/lib/sensu/api.rb
@@ -2,6 +2,7 @@ require File.join(File.dirname(__FILE__), 'base')
 require File.join(File.dirname(__FILE__), 'redis')
 
 gem 'thin', '1.5.0'
+gem 'sinatra', '1.3.5'
 gem 'async_sinatra', '1.0.0'
 
 require 'thin'

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency('amqp', '0.9.10')
   s.add_dependency('em-redis-unified', '0.4.1')
   s.add_dependency('thin', '1.5.0')
+  s.add_dependency('sinatra', '1.3.5')
   s.add_dependency('async_sinatra', '1.0.0')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
Sinatra version 1.4 causes some functionality within async_sinatra to break. Let's lock the sinatra version to 1.3.5 for now.
