### PR TITLE
GET & POST /stashes, pagination, aggregate issued data type

### DIFF
--- a/lib/sensu/api.rb
+++ b/lib/sensu/api.rb
@@ -356,7 +356,7 @@ module Sensu
       begin
         post_body = Oj.load(request.body.read)
         check_name = post_body[:check]
-        subscribers = post_body[:subscribers] || Array.new
+        subscribers = post_body[:subscribers]
         if check_name.is_a?(String) && subscribers.is_a?(Array)
           if $settings.check_exists?(check_name)
             check = $settings[:checks][check_name]

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -358,9 +358,7 @@ describe 'Sensu::API' do
     api_test do
       options = {
         :body => {
-          :subscribers => [
-            'test'
-          ]
+          :check => 'tokens'
         }
       }
       api_request('/request', :post, options) do |http, body|
@@ -375,7 +373,10 @@ describe 'Sensu::API' do
     api_test do
       options = {
         :body => {
-          :check => 'nonexistent'
+          :check => 'nonexistent',
+          :subscribers => [
+            'test'
+          ]
         }
       }
       api_request('/request', :post, options) do |http, body|


### PR DESCRIPTION
POST /stashes to create a stash, accepting a JSON post body with a path and content.
eg. {"path": "test", "content": {"key": "value"}}

GET /stashes returns an array of stashes.
eg. [{"path": "test", "content": {"key": "value"}}]

Pagination support, limit and offset GET params, currently applied to /clients and /stashes. Default is no limit.
eg. GET /clients?limit=100&offset=100

Aggregate issued timestamps are now integers.

Check request now returns a 202, as it publishes an AMQP payload.
