### PR TITLE
Add "nonzero" value in event data

### DIFF
--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -19,7 +19,8 @@ describe 'Sensu::API' do
               :status => 2,
               :issued => Time.now.to_i,
               :flapping => false,
-              :occurrences => 1
+              :occurrences => 1,
+              :nonzero => 1
             )) do
               redis.set('stash:test/test', '{"key": "value"}') do
                 redis.sadd('stashes', 'test/test') do
@@ -127,6 +128,7 @@ describe 'Sensu::API' do
         body[:status].should eq(2)
         body[:flapping].should be_false
         body[:occurrences].should eq(1)
+        body[:nonzero].should eq(1)
         body[:issued].should be_within(10).of(epoch)
         async_done
       end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -132,6 +132,7 @@ module Helpers
       :client => client,
       :check => check,
       :occurrences => 1,
+      :nonzero => 1,
       :action => :create
     }
   end


### PR DESCRIPTION
To easily replicate the current logic we have in place today to deal with check "tolerance" (what we call escalate), it would be handy to have an integer value in the event data telling how many times the check status was different from 0.
At first I thought "occurrences" was meant for that, but after a while using it I realized it represents how many times the latest check status was repeated (with the exception of exit code 0).
Of course both these values could be derived (by handlers) from the history data, but, given that "occurrences" is already there, I think "nonzero" has the same right to be there too ;) They are both a derived value of history that removes the need for a custom handler logic
