### PR TITLE
send back event with substituted command tokens

### DIFF
--- a/lib/sensu/client.rb
+++ b/lib/sensu/client.rb
@@ -99,6 +99,7 @@ module Sensu
         command, unmatched_tokens = substitute_command_tokens(check)
         check[:executed] = Time.now.to_i
         if unmatched_tokens.empty?
+          check[:command] = command
           execute = Proc.new do
             @logger.debug('executing check command', {
               :check => check


### PR DESCRIPTION
it's nice to have command with  substituted  :::name::: tokens be sent back to sensu server
and not as in definition, so actual values could be exposed to handers/murators/etc...
