### PR TITLE
Added masquerade feature

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -415,6 +415,10 @@ module Sensu
       @redis.get('client:' + result[:client]) do |client_json|
         unless client_json.nil?
           client = Oj.load(client_json)
+          if client[:masquerade]
+            client[:sender] = client[:name]
+            client[:name] = client[:masquerade]
+          end
           check = case
           when @settings.check_exists?(result[:check][:name])
             @settings[:checks][result[:check][:name]].merge(result[:check])

--- a/lib/sensu/socket.rb
+++ b/lib/sensu/socket.rb
@@ -27,10 +27,8 @@ module Sensu
           check[:issued] = Time.now.to_i
           check[:status] ||= 0
           if validates && check[:status].is_a?(Integer)
-            # if check has attr :masquerade, set client name to it, if not, use local client name
-            check[:masquerade] ? (client = check[:masquerade]) : (client = @settings[:client][:name])
             payload = {
-              :client => client,
+              :client => @settings[:client][:name],
               :check => check
             }
             @logger.info('publishing check result', {


### PR DESCRIPTION
This change adds a new feature where you can push check results via the socket as another client. A use case would be to monitor network devices or have another monitoring tool (ie Riemann) to send events to sensu. 
