### PR TITLE
Updating check validation for unpublished checks.

### DIFF
--- a/lib/sensu/settings.rb
+++ b/lib/sensu/settings.rb
@@ -210,7 +210,7 @@ module Sensu
     end
 
     def validate_check(check)
-      unless check[:interval].is_a?(Integer) && check[:interval] > 0
+      unless !check[:publish] || (check[:interval].is_a?(Integer) && check[:interval] > 0)
         invalid_check(check, 'check is missing interval')
       end
       unless check[:command].is_a?(String)

--- a/spec/config.json
+++ b/spec/config.json
@@ -96,6 +96,11 @@
     "merger": {
       "command": "this will be overwritten",
       "interval": 60
+    },
+    "unpublished": {
+      "command": "/bin/true",
+      "publish": false,
+      "subscribers":["test"]
     }
   },
   "client": {

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -13,6 +13,7 @@ describe 'Sensu::Settings' do
     @settings.should respond_to(:to_hash, :[], :check_exists?, :mutator_exists?, :handler_exists?)
     @settings.check_exists?('tokens').should be_true
     @settings.check_exists?('nonexistent').should be_false
+    @settings.check_exists?('unpublished').should be_true
     @settings.mutator_exists?('tag').should be_true
     @settings.mutator_exists?('nonexistent').should be_false
     @settings.handler_exists?('file').should be_true


### PR DESCRIPTION
Unpublished checks (configured with the 'publish' attribute as false) are not scheduled to run on any interval.  Hence, these checks do not require a valid interval to run.  This change updates the check validation to take this into consideration.
