### PR TITLE
handle nil status as unknown severity

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -198,6 +198,7 @@ module Sensu
     def event_handlers(event)
       handler_list = Array((event[:check][:handlers] || event[:check][:handler]) || 'default')
       handlers = derive_handlers(handler_list)
+      event[:check][:status] ||= 3
       event_severity = SEVERITIES[event[:check][:status]] || 'unknown'
       handlers.select do |handler|
         if event[:action] == :flapping && !handler[:handle_flapping]

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -219,6 +219,8 @@ describe 'Sensu::Server' do
       ]
     }
     @server.event_handlers(event).should eq(expected)
+    event[:check][:status] = nil
+    @server.event_handlers(event).should eq(expected)
     event[:check][:status] = 0
     event[:action] = :resolve
     @server.event_handlers(event).should eq(expected)


### PR DESCRIPTION
Assumes that if status doesn't exist, that we should set the severity to 'unknown'. This was exposed by a client library that our developers are currently using that wasn't verifying non-null statuses for checks.

We're addressing this in the library, but non-existent status will cause a Sensu server crash. This could be easily exploited to crash running sensu servers.
