### PR TITLE
Fixed sensu popen nil exit status

### DIFF
--- a/lib/sensu/io.rb
+++ b/lib/sensu/io.rb
@@ -68,7 +68,7 @@ module Sensu
         if wait_on_group
           wait_on_process_group(process.pid)
         end
-        [output, status.exitstatus]
+        [output, status.exited? ? status.exitstatus : 2]
       end
     end
   end


### PR DESCRIPTION
If a command does not properly exit, something has gone terribly wrong, and we do not want a nil exit status so set it to 2 (critical).
