### PR TITLE
follow symlinks in config directory once

### DIFF
--- a/lib/sensu/settings.rb
+++ b/lib/sensu/settings.rb
@@ -117,7 +117,7 @@ module Sensu
 
     def load_directory(directory)
       path = directory.gsub(/\\(?=\S)/, '/')
-      Dir.glob(File.join(path, '**/*.json')).each do |file|
+      Dir.glob(File.join(path, '**{,/*/**}/*.json')).uniq.each do |file|
         load_file(file)
       end
     end


### PR DESCRIPTION
If symlinks exist under CONFIG_DIR, then they won't be followed by old glob. New glob follows them exactly once, and returns immediate children. Unfortunately, if we include directories under CONFIG_DIR, this creates duplicate results, so we have to .uniq.
