### PR TITLE
Specs no longer use "echo -n" as a test shell command

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -68,7 +68,7 @@ describe 'Sensu::Client' do
         queue.subscribe do |payload|
           result = Oj.load(payload)
           result[:client].should eq('i-424242')
-          result[:check][:output].should eq('WARNING')
+          result[:check][:output].should eq("WARNING\n")
           result[:check].should have_key(:executed)
           async_done
         end
@@ -81,12 +81,12 @@ describe 'Sensu::Client' do
       result_queue do |queue|
         @client.setup_rabbitmq
         check = check_template
-        check[:command] = 'echo -n :::nested.attribute|default::: :::missing|default:::'
+        check[:command] = 'echo :::nested.attribute|default::: :::missing|default:::'
         @client.execute_check_command(check)
         queue.subscribe do |payload|
           result = Oj.load(payload)
           result[:client].should eq('i-424242')
-          result[:check][:output].should eq('true default')
+          result[:check][:output].should eq("true default\n")
           async_done
         end
       end
@@ -137,7 +137,7 @@ describe 'Sensu::Client' do
         queue.subscribe do |payload|
           result = Oj.load(payload)
           result[:client].should eq('i-424242')
-          result[:check][:output].should eq('WARNING')
+          result[:check][:output].should eq("WARNING\n")
           result[:check][:status].should eq(1)
           async_done
         end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -106,7 +106,7 @@ module Helpers
   def check_template
     {
       :name => 'foobar',
-      :command => 'echo -n WARNING && exit 1',
+      :command => 'echo WARNING && exit 1',
       :issued => epoch
     }
   end

--- a/spec/io_spec.rb
+++ b/spec/io_spec.rb
@@ -2,14 +2,14 @@ require File.dirname(__FILE__) + '/../lib/sensu/io.rb'
 
 describe 'Sensu::IO' do
   it 'can execute a command' do
-    output, status = Sensu::IO.popen('echo -n test')
-    output.should eq('test')
+    output, status = Sensu::IO.popen('echo test')
+    output.should eq("test\n")
     status.should eq(0)
   end
 
   it 'can execute a command with a non-zero exist status' do
-    output, status = Sensu::IO.popen('echo -n test && exit 1')
-    output.should eq('test')
+    output, status = Sensu::IO.popen('echo test && exit 1')
+    output.should eq("test\n")
     status.should eq(1)
   end
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -446,7 +446,7 @@ describe 'Sensu::Server' do
         queue.subscribe do |payload|
           check_request = Oj.load(payload)
           check_request[:name].should eq('foobar')
-          check_request[:command].should eq('echo -n WARNING && exit 1')
+          check_request[:command].should eq('echo WARNING && exit 1')
           check_request[:issued].should be_within(10).of(epoch)
           async_done
         end


### PR DESCRIPTION
The -n option to echo is only supported by certain shells (e.g. bash) and as a result the tests can fail on certain platforms - OSX being one example. This removes the use of the -n option and adjusts expected output values accordingly.
