### PR TITLE
expose settings to extension initialization

### DIFF
--- a/lib/sensu/base.rb
+++ b/lib/sensu/base.rb
@@ -53,12 +53,12 @@ module Sensu
       settings
     end
 
-    def extensions
+    def extensions(settings)
       extensions = Extensions.new
       if @options[:extension_dir]
         extensions.require_directory(@options[:extension_dir])
       end
-      extensions.load_all
+      extensions.load_all(settings)
       extensions
     end
 

--- a/lib/sensu/client.rb
+++ b/lib/sensu/client.rb
@@ -19,7 +19,7 @@ module Sensu
       base = Base.new(options)
       @logger = base.logger
       @settings = base.settings
-      @extensions = base.extensions
+      @extensions = base.extensions(@settings)
       base.setup_process
       @timers = Array.new
       @checks_in_progress = Array.new

--- a/lib/sensu/extensions.rb
+++ b/lib/sensu/extensions.rb
@@ -41,12 +41,12 @@ module Sensu
       end
     end
 
-    def load_all
+    def load_all(settings)
       require_directory(File.join(File.dirname(__FILE__), 'extensions'))
       EXTENSION_CATEGORIES.each do |category|
         extension_type = category.to_s.chop
         Extension.const_get(extension_type.capitalize).descendants.each do |klass|
-          extension = klass.new
+          extension = klass.new(settings)
           @extensions[category][extension.name] = extension
           loaded(extension_type, extension.name, extension.description)
         end
@@ -85,9 +85,9 @@ module Sensu
 
   module Extension
     class Base
-      def initialize
+      def initialize(settings)
         EM::next_tick do
-          post_init
+          post_init(settings)
         end
       end
 
@@ -114,7 +114,7 @@ module Sensu
         definition.has_key?(key.to_sym)
       end
 
-      def post_init
+      def post_init(settings={})
         true
       end
 

--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -21,7 +21,7 @@ module Sensu
       base = Base.new(options)
       @logger = base.logger
       @settings = base.settings
-      @extensions = base.extensions
+      @extensions = base.extensions(@settings)
       base.setup_process
       @timers = Array.new
       @master_timers = Array.new

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -24,7 +24,7 @@ describe 'Sensu::Base' do
   end
 
   it 'can load extensions' do
-    extensions = @base.extensions
+    extensions = @base.extensions(@base.settings)
     extensions.should respond_to(:[])
     extensions[:mutators].should be_kind_of(Hash)
     extensions[:handlers].should be_kind_of(Hash)

--- a/spec/extension_base_spec.rb
+++ b/spec/extension_base_spec.rb
@@ -5,7 +5,7 @@ describe 'Sensu::Extension::Base' do
   include Helpers
 
   it 'can run (nagios spec)' do
-    extension = Sensu::Extension::Base.new
+    extension = Sensu::Extension::Base.new(settings={})
     extension.should respond_to(:name, :description, :[])
     extension.name.should eq('base')
     extension['name'].should eq('base')
@@ -18,7 +18,7 @@ describe 'Sensu::Extension::Base' do
   end
 
   it 'can clean up before the process terminates' do
-    extension = Sensu::Extension::Base.new
+    extension = Sensu::Extension::Base.new(settings={})
     stopped = false
     extension.stop do
       stopped = true

--- a/spec/extensions_spec.rb
+++ b/spec/extensions_spec.rb
@@ -14,20 +14,20 @@ describe 'Sensu::Extensions' do
     @extensions[:mutators].should be_empty
     @extensions[:handlers].should be_kind_of(Hash)
     @extensions[:handlers].should be_empty
-    @extensions.load_all
+    @extensions.load_all(settings={})
     @extensions[:mutators]['only_check_output'].should be_an_instance_of(Sensu::Extension::OnlyCheckOutput)
     @extensions[:handlers]['debug'].should be_an_instance_of(Sensu::Extension::Debug)
   end
 
   it 'can load custom extensions and ignore those with syntax errors' do
     @extensions.require_directory(options[:extension_dir])
-    @extensions.load_all
+    @extensions.load_all(settings={})
     @extensions.mutator_exists?('opentsdb')
     @extensions[:mutators]['opentsdb'].should be_an_instance_of(Sensu::Extension::OpenTSDB)
   end
 
   it 'can stop all extensions for cleanup purposes' do
-    @extensions.load_all
+    @extensions.load_all(settings={})
     stopped_all = false
     @extensions.stop_all do
       stopped_all = true


### PR DESCRIPTION
Allow extensions to have access to settings during initialize and post_init (most importantly, the latter).
