### PR TITLE
Match redacted keys via end-anchored regex

### DIFF
--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -67,7 +67,7 @@ module Sensu
       ]
       hash = hash.dup
       hash.each do |key, value|
-        if keys.include?(key.to_s)
+        if keys.select{|k| key.to_s =~ /#{k}$/}.any?
           hash[key] = "REDACTED"
         elsif value.is_a?(Hash)
           hash[key] = redact_sensitive(value, keys)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -23,7 +23,9 @@ describe 'Sensu::Client' do
         queue.subscribe do |payload|
           keepalive = Oj.load(payload)
           keepalive[:name].should eq('i-424242')
+          keepalive[:service][:non_password_key].should eq('cleartext')
           keepalive[:service][:password].should eq('REDACTED')
+          keepalive[:service][:other_password].should eq('REDACTED')
           async_done
         end
       end

--- a/spec/config.json
+++ b/spec/config.json
@@ -113,7 +113,9 @@
       "attribute": true
     },
     "service": {
-      "password": "secret"
+      "non_password_key": "cleartext",
+      "password": "secret",
+      "other_password": "sauce"
     }
   }
 }


### PR DESCRIPTION
Even though custom redactions are possible, a lot of configuration can be avoided by matching redactions via regex anchored to the end of key names, ie - `something_password` is pretty surely going to be sensitive data.
