### PR TITLE
allow arbitrary client json attributes to be marged into keepalive results payload

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -586,7 +586,7 @@ module Sensu
                 if client[:keepalive].has_key?(:thresholds)
                   thresholds.merge!(client[:keepalive][:thresholds])
                 end
-                check[:refresh] = client[:keepalive][:refresh] if client[:keepalive].has_key?(:refresh)
+                check.merge!(client[:keepalive][:attributes]) { |key, v1, v2| v1 } if client[:keepalive].has_key?(:attributes)
               end
               time_since_last_keepalive = Time.now.to_i - client[:timestamp]
               case

--- a/lib/sensu/settings.rb
+++ b/lib/sensu/settings.rb
@@ -434,9 +434,9 @@ module Sensu
             end
           end
         end
-        if @settings[:client][:keepalive].has_key?(:refresh)
-          unless @settings[:client][:keepalive][:refresh].is_a?(Integer)
-            invalid('client keepaalive refresh interval must be an integer')
+        if @settings[:client][:keepalive].has_key?(:attributes)
+          unless @settings[:client][:keepalive][:refresh].is_a?(Hash)
+            invalid('client keepalive attributes must be a hash')
           end
         end
         if @settings[:client][:keepalive].has_key?(:thresholds)


### PR DESCRIPTION
```
{
  "client": {
    "name": "example.com",
    "address": "127.0.0.1",
    "subscriptions": [ "a", "b" ],
    "keepalive": {
      "thresholds": {
        "warning": 60,
        "critical": 180
      },
      "handler": "keepalive",
      "attributes": {
        "refresh": 600
        "blah": "foo"
      }
    }
  }
}
```
