### PR TITLE
[prefetch] allow users to set rabbitmq prefetch (channel)

### DIFF
--- a/lib/sensu/rabbitmq.rb
+++ b/lib/sensu/rabbitmq.rb
@@ -77,9 +77,15 @@ module Sensu
         error = RabbitMQError.new('rabbitmq channel closed')
         @on_error.call(error)
       end
+      prefetch = 1
+      if options.is_a?(Hash)
+        prefetch = options[:prefetch] || 1
+      end
       @channel.on_recovery do
         @after_reconnect.call
+        @channel.prefetch(prefetch)
       end
+      @channel.prefetch(prefetch)
     end
 
     def connected?

--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -72,11 +72,9 @@ module Sensu
       end
       @rabbitmq.after_reconnect do
         @logger.info('reconnected to rabbitmq')
-        @amq.prefetch(1)
         resume
       end
       @amq = @rabbitmq.channel
-      @amq.prefetch(1)
     end
 
     def setup_keepalives(&block)


### PR DESCRIPTION
```
      - consumers w/ no_ack ignore prefetch (client queues etc)
```
