### PR TITLE
Updates `redact_sensitive` to properly redact changes hashes

### DIFF
--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -71,6 +71,10 @@ module Sensu
           hash[key] = "REDACTED"
         elsif value.is_a?(Hash)
           hash[key] = redact_sensitive(value, keys)
+        elsif value.is_a?(Array) && value.size == 2
+          hash[key] = value.map do |diff|
+            redact_sensitive(diff, keys) if diff.is_a?(Hash) && !diff.nil?
+          end
         end
       end
       hash


### PR DESCRIPTION
Before this change, the  call to `redact_sensitive` in `Sensu::Settings#load_file(file)` did not actually redact any information, our logs looked like this (this is with me adding output to the log for debugging purposes:

``` JSON
{"timestamp":"2013-10-22T22:12:25.471181+0000","level":"warn","message":"pre-redact hash","hash":"Hash: {:ponymailer=>[nil, {:hostname=>\"smtp.gmail.com\", :post=>587, :smtp_domain=>\"domain.com\", :username=>\"service@domain.com\", :password=>\"this should be REDACTED\", :from=>\"service@domain.com\", :tls=>true, :authenticate=>true, :recipients=>[\"aws@domain.com\"]}]}"}

{"timestamp":"2013-10-22T22:12:25.471440+0000","level":"warn","message":"post-redact hash","hash":{"ponymailer":[null,{"hostname":"smtp.gmail.com","post":587,"smtp_domain":"domain.com","username":"service@domain.com","password":"this should be REDACTED","from":"service@domain.com","tls":true,"authenticate":true,"recipients":["aws@domain.com"]}]}}

{"timestamp":"2013-10-22T22:12:25.471685+0000","level":"warn","message":"config file applied changes","config_file":"/etc/sensu/conf.d/ponymailer.json","changes":{"ponymailer":[null,{"hostname":"smtp.gmail.com","post":587,"smtp_domain":"domain.com","username":"service@domain.com","password":"this should be REDACTED","from":"service@domain.com","tls":true,"authenticate":true,"recipients":["aws@domain.com"]}]}}
```

After adding the change, our logs now look like this:

``` JSON
{"timestamp":"2013-10-23T15:59:48.542239+0000","level":"warn","message":"config file applied changes","config_file":"/etc/sensu/conf.d/ponymailer.json","changes":{"ponymailer":[null,{"hostname":"smtp.gmail.com","post":587,"smtp_domain":"domain.com","username":"service@domain.com","password":"REDACTED","from":"service@domain.com","tls":true,"authenticate":true,"recipients":["aws@domain.com"]}]}}
```
