### PR TITLE
only process results younger than the check interval

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -483,10 +483,18 @@ module Sensu
       end
       @result_queue.subscribe(:ack => true) do |header, payload|
         result = Oj.load(payload)
-        @logger.debug('received result', {
-          :result => result
-        })
-        process_result(result)
+        age = Time.now.to_i - result[:check][:issued]
+        if age >= result[:check][:interval]
+          # event has expired
+          @logger.debug("skipping result (expired #{age})", {
+            :result => result
+          })
+        else
+          @logger.debug('received result', {
+            :result => result
+          })
+          process_result(result)
+        end
         EM::next_tick do
           header.ack
         end


### PR DESCRIPTION
per https://github.com/sensu/sensu/issues/646

By processing only "recent" results, it ensures the sensu is as close to real time as possible even in high load scenarios. 
