### PR TITLE
[rabbitmq] Updates RabbitMQ#connect to allow configurable EM timeout

### DIFF
--- a/lib/sensu/rabbitmq.rb
+++ b/lib/sensu/rabbitmq.rb
@@ -47,8 +47,7 @@ module Sensu
     end
 
     def connect(options={})
-      em_timeout = options[:em_timeout].to_i || 10
-      timeout = EM::Timer.new(em_timeout) do
+      timeout = EM::Timer.new(options[:em_timeout]) do
         e = "timed out after #{em_timeout}s while attempting to connect"
         error = RabbitMQError.new(e)
         @on_error.call(error)
@@ -100,6 +99,10 @@ module Sensu
 
     def self.connect(options={})
       options ||= Hash.new
+      unless options.has_key?(:em_timeout) && options[:em_timeout].is_a?(Integer)
+        options[:em_timeout] = 10 if options[:em_timeout].nil?
+        options[:em_timeout] = options[:em_timeout].to_i
+      end
       rabbitmq = self.new
       rabbitmq.connect(options)
       rabbitmq


### PR DESCRIPTION
Currently, with the unconfigurable 10 second timeout, it's become an annoyance where several nodes will timeout while attempting to connect to RabbitMQ, seemingly due to random network latency in EC2. These nodes then stop their sensu-client service and leave a number of events hanging around, causing our sensu-server's load to spike when running all the event handlers, causing another alert, and ultimately requiring a manual `knife ssh 'name: ...' 'sudo service sensu-client restart'` to resolve the errors. 

This adds an option to allow users to configure their own timeout to hopefully alleviate this issue. 
