### PR TITLE
Contribute some patch 

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -587,6 +587,9 @@ module Sensu
               when check[:ignore]
                 check[:output] = 'Ignore keep-alive check for this client'
                 check[:status] = 0
+              when time_since_last_keepalive < 0
+                check[:output] = 'Negative keep-alive timestamp found for this client'
+                check[:status] = 3
               when time_since_last_keepalive >= check[:thresholds][:critical]
                 check[:output] = 'No keep-alive sent from client in over '
                 check[:output] << check[:thresholds][:critical].to_s + ' seconds'


### PR DESCRIPTION
1. Handle negative escaped time
   This can be occurred when some one change server's local time
2. Add ignore option for changing keep-alive check dynamically!
   Give flexiable configration for client keep-alive mechanism
3. Use server's time for all the client's timestamp, so we can give up NTP Server
   In most ENV, there is no condition to build a ntp server.
   Any MORE, We can just correct server's time enough if we use this patch
