### PR TITLE
protection against malformed json

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -385,6 +385,7 @@ module Sensu
       @logger.debug('processing result', {
         :result => result
       })
+
       @redis.get('client:' + result[:client]) do |client_json|
         unless client_json.nil?
           client = Oj.load(client_json)
@@ -486,7 +487,15 @@ module Sensu
         @logger.debug('received result', {
           :result => result
         })
-        process_result(result)
+        # Protection against direct injection
+        # with bad format into RabbitMq 
+        unless result[:client].nil?
+          process_result(result)
+        else
+          @logger.debug('Malformed json received', {
+            :result => result
+          })
+        end
         EM::next_tick do
           header.ack
         end


### PR DESCRIPTION
We discover today that a malformed json inserted directly into RabbitMQ could crash the sensu-server. This little check prevent it to crash. 
