### PR TITLE
Store all event data (snapshot)

### DIFF
--- a/lib/sensu/cli.rb
+++ b/lib/sensu/cli.rb
@@ -1,5 +1,5 @@
-require 'sensu/logger/constants'
 require 'optparse'
+require 'sensu/logger/constants'
 
 module Sensu
   class CLI

--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -1,3 +1,7 @@
+gem 'uuidtools', '2.1.4'
+
+require 'uuidtools'
+
 module Sensu
   module Utilities
     def testing?
@@ -25,6 +29,10 @@ module Sensu
         end
       end
       merged
+    end
+
+    def random_uuid
+      UUIDTools::UUID.random_create.to_s
     end
 
     def redact_sensitive(hash, keys=nil)

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('json') if RUBY_VERSION < "1.9"
   s.add_dependency('multi_json', '1.10.1')
+  s.add_dependency('uuidtools', '2.1.4')
   s.add_dependency('sensu-em', '2.0.0')
   s.add_dependency('sensu-logger', '0.0.1')
   s.add_dependency('sensu-settings', '0.0.3')

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -53,7 +53,7 @@ describe 'Sensu::Client' do
         queue.subscribe do |payload|
           result = MultiJson.load(payload)
           expect(result[:client]).to eq('i-424242')
-          expect(result[:check][:name]).to eq('foobar')
+          expect(result[:check][:name]).to eq('test')
           async_done
         end
       end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -109,7 +109,7 @@ module Helpers
 
   def check_template
     {
-      :name => 'foobar',
+      :name => 'test',
       :command => 'echo WARNING && exit 1',
       :issued => epoch
     }
@@ -133,6 +133,7 @@ module Helpers
     check[:status] = 1
     check[:history] = [1]
     {
+      :id => UUIDTools::UUID.random_create.to_s,
       :client => client,
       :check => check,
       :occurrences => 1,


### PR DESCRIPTION
Storing all of the event data produces snapshots, check and client data at that time. Added an event ID (UUID).

This change will break current dashboards and tooling that queries the API for event data.

`API /events`

``` json
[
    {
        "id": "1ccfdf59-d9ab-447c-ac11-fd84072b905a",
        "client": {
            "name": "i-424242",
            "address": "127.0.0.1",
            "subscriptions": [
                "test"
            ],
            "nested": {
                "attribute": true
            },
            "service": {
                "password": "REDACTED"
            },
            "keepalive": {
                "thresholds": {
                    "warning": 10
                }
            },
            "timestamp": 1389374650
        },
        "check": {
            "command": "echo -n :::name::: :::nested.attribute::: && exit 2",
            "subscribers": [
                "test"
            ],
            "interval": 1,
            "name": "tokens",
            "issued": 1389374667,
            "executed": 1389374667,
            "output": "-n i-424242 true\n",
            "status": 2,
            "duration": 0.005,
            "history": [
                "2",
                "2",
                "2",
                "2",
                "2",
                "2",
                "2",
                "2",
                "2",
                "2",
                "2",
                "2",
                "2",
                "2",
                "2",
                "2",
                "2"
            ]
        },
        "occurrences": 1,
        "action": "create"
    },
    {
        "id": "3a3f9c37-fb08-408e-a2f3-3bb499815261",
        "client": {
            "name": "i-424242",
            "address": "127.0.0.1",
            "subscriptions": [
                "test"
            ],
            "nested": {
                "attribute": true
            },
            "service": {
                "password": "REDACTED"
            },
            "keepalive": {
                "thresholds": {
                    "warning": 10
                }
            },
            "timestamp": 1389374650
        },
        "check": {
            "command": "echo -n foobar && exit 1",
            "standalone": true,
            "interval": 1,
            "name": "standalone",
            "issued": 1389374667,
            "executed": 1389374667,
            "output": "-n foobar\n",
            "status": 1,
            "duration": 0.005,
            "history": [
                "1",
                "1",
                "1",
                "1",
                "1",
                "1",
                "1",
                "1",
                "1",
                "1",
                "1",
                "1",
                "1",
                "1",
                "1"
            ]
        },
        "occurrences": 1,
        "action": "create"
    }
]
```
