### PR TITLE
Fix check extensions

### DIFF
--- a/lib/sensu/client.rb
+++ b/lib/sensu/client.rb
@@ -158,7 +158,7 @@ module Sensu
       })
       check[:executed] = Time.now.to_i
       extension = @extensions[:checks][check[:extension]]
-      extension.safe_run do |output, status|
+      extension.safe_run(check) do |output, status|
         check[:output] = output
         check[:status] = status
         publish_result(check)

--- a/lib/sensu/client.rb
+++ b/lib/sensu/client.rb
@@ -182,8 +182,8 @@ module Sensu
         else
           execute_check_command(check)
         end
-      else
-        if @extensions.check_exists?(check[:name])
+      elsif check.has_key?(:extension)
+        if @extensions.check_exists?(check[:extension])
           run_check_extension(check)
         else
           @logger.warn('unknown check extension', {

--- a/lib/sensu/client.rb
+++ b/lib/sensu/client.rb
@@ -157,7 +157,7 @@ module Sensu
         :check => check
       })
       check[:executed] = Time.now.to_i
-      extension = @extensions[:checks][check[:name]]
+      extension = @extensions[:checks][check[:extension]]
       extension.safe_run do |output, status|
         check[:output] = output
         check[:status] = status

--- a/lib/sensu/settings.rb
+++ b/lib/sensu/settings.rb
@@ -217,8 +217,8 @@ module Sensu
       unless (check[:interval].is_a?(Integer) && check[:interval] > 0) || !check[:publish]
         invalid_check(check, 'check is missing interval')
       end
-      unless check[:command].is_a?(String) or check[:extension].is_a?(String)
-        invalid_check(check, 'check is missing required key: command or extension')
+      unless (check[:command].is_a?(String) ^ check[:extension].is_a?(String))
+        invalid_check(check, 'check configuration is invalid command xor extension')
       end
       if check.has_key?(:standalone)
         unless !!check[:standalone] == check[:standalone]

--- a/lib/sensu/settings.rb
+++ b/lib/sensu/settings.rb
@@ -217,8 +217,8 @@ module Sensu
       unless (check[:interval].is_a?(Integer) && check[:interval] > 0) || !check[:publish]
         invalid_check(check, 'check is missing interval')
       end
-      unless check[:command].is_a?(String)
-        invalid_check(check, 'check is missing command')
+      unless check[:command].is_a?(String) or check[:extension].is_a?(String)
+        invalid_check(check, 'check is missing required key: command or extension')
       end
       if check.has_key?(:standalone)
         unless !!check[:standalone] == check[:standalone]


### PR DESCRIPTION
This change addresses an issue preventing extension checks from working by validating check configurations contain either a :command or :extension key.

It also allows extension checks to set the extension to be run based on check[:extension] rather than check[:name].  This allows for one extension to be scheduled many times with unique names and (potentially) different parameters.

I've tested this briefly on 0.12.1 with much success and happiness.  