### PR TITLE
Make sensu server not merge check data when the check is stand_alone

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -413,7 +413,7 @@ module Sensu
         unless client_json.nil?
           client = Oj.load(client_json)
           check = case
-          when @settings.check_exists?(result[:check][:name])
+          when @settings.check_exists?(result[:check][:name]) && !result[:check][:standalone]
             @settings[:checks][result[:check][:name]].merge(result[:check])
           else
             result[:check]


### PR DESCRIPTION
I just want to spark the conversation, if approved I'll try to add tests. (I don't know much ruby)

I have this situation with @bobtfish where we have lots of standalone checks in a multi-tenant environment. (also, the default configuration when the puppet module is uses, `standalone => true`)

But, in the situation where a client sends in a check result from the standalone check, and it is "missing" a critical piece of metadata, say `pagerduty_api_key`, the _server_ gleefully fills in this data with this merge.

In my particular situation this results in lots of pages going to a the team that owns the sensu _server_ (Ops), and not to the team that owns the client (not Ops).

Can we make the sensu server _not_ perform this merge when the check is standalone? It seems like a standalone check should have all settings it needs to do its job, and the server shouldn't be filling in the blanks just because it also happens to have the same check defined for itself, with different settings.

Or, let me know if this is not the design you want sensu to take, and I can come up with a different workaround (prepend all checks with the hostname so the check names never merge?)
