### PR TITLE
Added parameters option to api check request handler

### DIFF
--- a/lib/sensu/api.rb
+++ b/lib/sensu/api.rb
@@ -383,7 +383,8 @@ module Sensu
     apost '/request/?' do
       rules = {
         :check => {:type => String, :nil_ok => false},
-        :subscribers => {:type => Array, :nil_ok => true}
+        :subscribers => {:type => Array, :nil_ok => true},
+        :parameters => {:type => Object, :nil_ok => true}
       }
       read_data(rules) do |data|
         if settings.checks[data[:check]]
@@ -394,6 +395,9 @@ module Sensu
             :command => check[:command],
             :issued => Time.now.to_i
           }
+          if data[:parameters] != nil
+              payload[:command] = payload[:command] % data[:parameters]
+          end
           settings.logger.info('publishing check request', {
             :payload => payload,
             :subscribers => subscribers


### PR DESCRIPTION
I had a requirement to be able to provide some parameters to a check via the check request API. Typically useful for unpublished, ad-hoc checks where you want to issue a command to a set of clients but set some parameters to that command at run-time.

Not a ruby expert, but this seems like the simplest approach that's tolerant of cases where the command has a placeholder but no params are supplied, or vice versa.
