### PR TITLE
Users can define a "keepalive" handler

### DIFF
--- a/spec/config.json
+++ b/spec/config.json
@@ -37,6 +37,12 @@
         "debug"
       ]
     },
+    "keepalive": {
+      "type": "set",
+      "handlers": [
+        "debug"
+      ]
+    },
     "file": {
       "type": "pipe",
       "command": "cat > /tmp/sensu_event"

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -490,6 +490,7 @@ describe 'Sensu::Server' do
                   redis.hget('events:bar', 'keepalive') do |event_json|
                     event = MultiJson.load(event_json)
                     expect(event[:check][:status]).to eq(2)
+                    expect(event[:check][:handler]).to eq('keepalive')
                     async_done
                   end
                 end


### PR DESCRIPTION
- Used as default handler for keepalive events when it exists
