### PR TITLE
Previous_occurrence not correctly referencing status

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -414,7 +414,7 @@ module Sensu
                   :occurrences => 1
                 }
                 if check[:status] != 0 || is_flapping
-                  if previous_occurrence && check[:status] == previous_occurrence[:status]
+                  if previous_occurrence && check[:status] == previous_occurrence[:check][:status]
                     event[:occurrences] = previous_occurrence[:occurrences] + 1
                   end
                   event[:action] = is_flapping ? :flapping : :create


### PR DESCRIPTION
When sensu-server pulls in 'previous_occurrences', it compares the existing status vs. the previous occurrence's one. It appears that this is being improperly referenced. The result is that checks with 'occurrences' set greater than 1 are not getting properly handled.

The status code for the previous occurrence is in previous_occurrence[:check][:status], and not previous_occurrence[:status]. This is easier to explain with a commit: https://github.com/robbydyer/sensu/commit/4aa7c461b530c4467e251b282d52d849f67ffc39
