### PR TITLE
Feature - command check attributes substitution

### DIFF
--- a/lib/sensu/client.rb
+++ b/lib/sensu/client.rb
@@ -89,7 +89,7 @@ module Sensu
       end
       substituted = substituted.gsub(/@@@([^:].*?)@@@/) do
         token = $1.to_s
-        matched = find_client_attribute(@settings[:check], token.split('.'), nil)
+        matched = find_client_attribute(check, token.split('.'), nil)
         if matched.nil?
           unmatched_tokens << token
         end

--- a/lib/sensu/client.rb
+++ b/lib/sensu/client.rb
@@ -87,6 +87,14 @@ module Sensu
         end
         matched
       end
+      substituted = substituted.gsub(/@@@([^:].*?)@@@/) do
+        token = $1.to_s
+        matched = find_client_attribute(@settings[:check], token.split('.'), nil)
+        if matched.nil?
+          unmatched_tokens << token
+        end
+        matched
+      end
       [substituted, unmatched_tokens]
     end
 


### PR DESCRIPTION
This implements check command token substitution from check attributes.
Why this can be useful, hmm ... while writing a meta check - a check which send many self generated check events through local client  tcp/udp 3030 socket, i hit a need that i wanted to inherit the metacheck occurences,interval&refresh parameters and push them in the generated check events. Why? since i want the checks to have same alerting logic in handlers as defined fo the meta check.

Since there is no direct way to access settings in sensu pipe checks one way is to load the sensu client json settings with
require 'sensu-plugin/utils'
include Sensu::Plugin::Utils
and then access check attributes with settings[:checks]['check_name']
where check_name must be hard coded which is not good
and as well loading all sensu json configs each time sensu check runs is a bit heavy operation.

Another way is to get check attributes from the api - but it's even worser idea.

The most reasonable and clean seems like command token substitution for example

    {
      "checks": {
        "check_smthing": {
          "command": "/etc/sensu/plugins/meta-check-smthing.rb --occurences @@@occurences@@@ --refresh @@@refresh@@@ --interval @@@interval@@@",
          "interval": 60,
          "occurrences": 5,
          "refresh": 3600,
          "subscribers": [ "blah" ],
          "handlers": [ "default" ]
        }
      }
    }
