### PR TITLE
Ensure that we don't get stuck with a bad message in queue

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -460,14 +460,14 @@ module Sensu
             :result => result
           })
           process_result(result)
-          EM::next_tick do
-            @transport.ack(message_info)
-          end
         rescue MultiJson::ParseError => error
           @logger.error('failed to parse result payload', {
             :message => message,
             :error => error.to_s
           })
+        end
+        EM::next_tick do
+          @transport.ack(message_info)
         end
       end
     end


### PR DESCRIPTION
If a bad JSON message is received, the begin/rescue will be executed
without acknowledging handling of this (bad) result. So we end up with no more messages being processed because of a bad result that MultiJson can't parse (UTF-8 issue like in #783).

I've move it out of the begin/rescue block to make sure we do ACK the message (and have it "disappear").

It works so far in our dev environment, thought I'm not 100% sure if this is the best/correct way to handle this case.
