### PR TITLE
Add "time since last keepalive" to log messages

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -580,18 +580,22 @@ module Sensu
               check[:issued] = Time.now.to_i
               check[:executed] = Time.now.to_i
               time_since_last_keepalive = Time.now.to_i - client[:timestamp]
+              lag_message = time_since_last_keepalive.to_s
               case
               when time_since_last_keepalive >= check[:thresholds][:critical]
                 check[:output] = 'No keep-alive sent from client in over '
                 check[:output] << check[:thresholds][:critical].to_s + ' seconds'
+                check[:output] << ' (last check ' + lag_message + ' seconds ago)'
                 check[:status] = 2
               when time_since_last_keepalive >= check[:thresholds][:warning]
                 check[:output] = 'No keep-alive sent from client in over '
                 check[:output] << check[:thresholds][:warning].to_s + ' seconds'
+                check[:output] << ' (last check ' + lag_message + ' seconds ago)'
                 check[:status] = 1
               else
                 check[:output] = 'Keep-alive sent from client less than '
                 check[:output] << check[:thresholds][:warning].to_s + ' seconds ago'
+                check[:output] << ' (last check ' + lag_message + ' seconds ago)'
                 check[:status] = 0
               end
               publish_result(client, check)


### PR DESCRIPTION
This helps diagnose cases where keepalive thresholds are set too
aggressively, and keepalives are continously coming in 5-20 seconds
above the threshold.
