### PR TITLE
Add the Event ID to log messages

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -266,7 +266,8 @@ module Sensu
               output.each_line do |line|
                 @logger.info('handler output', {
                   :handler => handler,
-                  :output => line
+                  :output => line,
+                  :event_id => event['id']
                 })
               end
               @handlers_in_progress_count -= 1


### PR DESCRIPTION
This helps group two things:
- Handlers that output multiple lines of log messages: these log lines
  are spread across multiple JSON blobs, making start and end less
  obvious.
- Multiple different handlers handling the same data will all be
  associated with each other.
