### PR TITLE
[Feedback Requested] Attempt to reconnect if a RabbitMQ or Redis error occurs

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -132,10 +132,11 @@ module Sensu
       Transport.logger = @logger
       @transport = Transport.connect(transport_name, transport_settings)
       @transport.on_error do |error|
-        @logger.fatal('transport connection error', {
+        @logger.error('transport connection error', {
           :error => error.to_s
         })
-        stop
+        pause
+        setup_transport
       end
       @transport.before_reconnect do
         unless testing?
@@ -155,10 +156,11 @@ module Sensu
       })
       @redis = Redis.connect(@settings[:redis])
       @redis.on_error do |error|
-        @logger.fatal('redis connection error', {
+        @logger.error('redis connection error', {
           :error => error.to_s
         })
-        stop
+        pause
+        setup_redis
       end
       @redis.before_reconnect do
         unless testing?


### PR DESCRIPTION
This fix works in my environment and I believe it's a good/possible fix for #815 and #599. See my comment https://github.com/sensu/sensu/issues/815#issuecomment-70260550 fully explaining the cycle. Summary: In an HA environment it's possible that something like Redis will fail and while the load balancer swaps over to the new Redis master one of 2 things could happen:

1. The load balancer swaps to the new Redis before it has fully achieved master status. Thus, Sensu will receive a "READONLY slave" error. Let's assume that the error will eventually resolve itself and keep trying.
1. When Sensu disconnects from Redis it also unsubscribes from the RabbitMQ keepalive and results queue. As a result, the `sensu-api` process will try to reconnect to RabbitMQ, and when those queues are not available it will bomb out and kill the process. Again, let's assume that the situation is not fatal and keep trying. 

Even in a non-HA environment I don't see the harm in throwing an error (logging it) and retrying. The situation may not correct itself but then it will just cycle until someone looks at the logs and see it's not working. Or better yet, they're monitoring Sensu API health and will notice it's not connected to Redis and/or RabbitMQ.

Do you think this might be an acceptable answer to these issues? If not, what else can we do? As it stands Sensu is completely vulnerable to Redis failures even when Redis is set up in a cluster.

Thanks for your consideration.