### PR TITLE
Add support for a subdue 'schedule' to give more flexibility

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -48,6 +48,25 @@ module Sensu
 
     def action_subdued?(condition)
       subdued = false
+      if condition.has_key?(:schedule)
+        now = Time.now
+        day_of_week = now.wday
+        timepairs = condition[:schedule][day_of_week]
+        # If timepairs isn't an array, then there was no entry for today
+        if timepairs.kind_of?(Array)
+           if timepairs.length == 0
+             # No times given - subdue for the whole day
+             subdued = true
+           else
+             timepairs.each do |timepair|
+              if now.between?(Time.parse(timepair[0]), Time.parse(timepair[1]))
+                subdued = true
+                break
+              end
+            end
+          end
+        end
+      end
       if condition.has_key?(:begin) && condition.has_key?(:end)
         begin_time = Time.parse(condition[:begin])
         end_time = Time.parse(condition[:end])

--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -50,8 +50,7 @@ module Sensu
       subdued = false
       if condition.has_key?(:schedule)
         now = Time.now
-        day_of_week = now.wday
-        timepairs = condition[:schedule][day_of_week]
+        timepairs = condition[:schedule][now.wday.to_s]
         # If timepairs isn't an array, then there was no entry for today
         if timepairs.kind_of?(Array)
            if timepairs.length == 0


### PR DESCRIPTION
This is a first-stab at a subdue 'schedule' which would give more flexibility in setting subdue times over the current subdue code.

The idea is that in the config you can set a subdue schedule which allows multiple subdue periods across a day - using day of week number as key, and a list of lists for begin and end pairs. For example to subdue checks completely on Saturday and Sunday, outside of 9-5 Monday, outside 10-4 on a Friday, and not at all for the rest of the week, you would add the following config:

``` json
"subdue": {
  "schedule": {
    "0": [],
    "1": [
          ["00:00", "'09:00"],
          ["17:00", "23:59:59"]
        ],
    "5": [
          ["00:00", "10:00"],
          ["16:00", "23:59:59"]
        ],
    "6": []
  }
}
```

I've tested the code, and it seems to do what I expect, but I would appreciate a review!  I'm also happy for any changes to the config structure (e.g. using day names instead of numbers) if preferred. I've added this functionality alongside the existing subdue options, so that it would be backwards compatible, but I've not thought much/tested how this would play out if both old and new options were set.

Mostly I'm just keen to know if this is a useful change!