### PR TITLE
Filter attributes need to both be strings to compare correctly.

### DIFF
--- a/lib/sensu/server.rb
+++ b/lib/sensu/server.rb
@@ -90,7 +90,7 @@ module Sensu
     def filter_attributes_match?(hash_one, hash_two)
       hash_one.keys.all? do |key|
         case
-        when hash_one[key] == hash_two[key]
+        when hash_one[key].to_s == hash_two[key].to_s
           true
         when hash_one[key].is_a?(Hash) && hash_two[key].is_a?(Hash)
           filter_attributes_match?(hash_one[key], hash_two[key])


### PR DESCRIPTION
While trying to implement a filter for events with `:action=>:resolve` I realized that the value of `:action` in the Sensu Event is a symbol and my filter attributes are in JSON.  The values of [`hash_one[key]` and `hash_two[key]`](https://github.com/sensu/sensu/blob/master/lib/sensu/server.rb#L93) need to be converted to a string before they can accurately be compared.

##### Example Filter JSON: 
 ```JSON
{
  "filters": {
    "do_not_resolve": {
      "attributes": {
        "check": {
          "do_not_resolve": true
        },
        "action": "resolve"
      },
      "negate": true
    }
  }
}
```

##### Example Sensu Event:
```Ruby
{
  :id=>"b024326c-ef4a-4d56-95f9-72332e5a2702", 
  :client=>{
    :name=>"rt4.prod.example.com",
    :address=>"198.11.254.108", 
    :subscriptions=>["base", "rt4.prod.example.com", "testing"], 
    :keepalive=>{
      :thresholds=>{
        :warning=>120, 
        :critical=>180
      }, 
      :handlers=>["default", "pagerduty"], 
      :refresh=>1800
    }, 
    :version=>"0.13.1", 
    :timestamp=>1421791596
  }, 
  :check=>{
    :command=>"monitor_that_pid.sh", 
    :subscribers=>["testing"], 
    :handlers=>["default", "pagerduty"], 
    :refresh=>1800, 
    :interval=>60, 
    :description=>"Monitors Some PID", 
    :do_not_resolve=>true,
    :name=>"monitor_some_pid", 
    :issued=>1421791537, 
    :executed=>1421791537, 
    :duration=>0.013, 
    :output=>"OK", 
    :status=>0, 
    :history=>["2", "2", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "2", "2", "2", "2", "2", "2", "0"]
  }, 
  :occurrences=>6, 
  :action=>:resolve
}
```

I'm pretty sure, at the moment, filtering on any Event `:action` is broken since the actions are symbolized and you can only have a string in the Filter attribute JSON.

I've tested a decent bit, but would appreciate a review or any comments/suggestions!