### PR TITLE
Use the basic JSON gem to detect parsing errors in received data.

### DIFF
--- a/lib/sensu/constants.rb
+++ b/lib/sensu/constants.rb
@@ -1,6 +1,6 @@
 module Sensu
   unless defined?(Sensu::VERSION)
-    VERSION = '0.16.0'
+    VERSION = '0.16.1'
 
     SEVERITIES = %w[ok warning critical unknown]
 

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake', '~> 10.3')
   s.add_development_dependency('rspec', '~> 3.0.0')
   s.add_development_dependency('em-http-request', '~> 1.1')
+  s.add_development_dependency('yajl-ruby')
 
   s.files         = Dir.glob('{bin,lib}/**/*') + %w[sensu.gemspec README.md CHANGELOG.md MIT-LICENSE.txt]
   s.executables   = Dir.glob('bin/**/*').map { |file| File.basename(file) }


### PR DESCRIPTION
I discovered that if MultiJson is using Yajl to process JSON, and your Sensu messages are too big to fit in one packet, Sensu will not wait for all the packets to arrive before attempting to process the message. This PR fixes that.