### PR TITLE
Dynamic parameters on check execution from API

### DIFF
--- a/lib/sensu/api.rb
+++ b/lib/sensu/api.rb
@@ -416,6 +416,7 @@ module Sensu
         :subscribers => {:type => Array, :nil_ok => true},
         :kwargs =>  {:type => Hash, :nil_ok => true}
       }
+      
       read_data(rules) do |data|
         if settings.checks[data[:check]]
           check = settings.checks[data[:check]]

--- a/lib/sensu/api.rb
+++ b/lib/sensu/api.rb
@@ -413,7 +413,8 @@ module Sensu
     apost '/request/?' do
       rules = {
         :check => {:type => String, :nil_ok => false},
-        :subscribers => {:type => Array, :nil_ok => true}
+        :subscribers => {:type => Array, :nil_ok => true},
+        :kwargs =>  {:type => Hash, :nil_ok => true}
       }
       read_data(rules) do |data|
         if settings.checks[data[:check]]
@@ -422,6 +423,7 @@ module Sensu
           payload = {
             :name => data[:check],
             :command => check[:command],
+            :kwargs =>  data[:kwargs],
             :issued => Time.now.to_i
           }
           settings.logger.info('publishing check request', {

--- a/lib/sensu/client.rb
+++ b/lib/sensu/client.rb
@@ -79,7 +79,15 @@ module Sensu
       unmatched_tokens = Array.new
       substituted = check[:command].gsub(/:::([^:].*?):::/) do
         token, default = $1.to_s.split('|', -1)
-        matched = find_client_attribute(@settings[:client], token.split('.'), default)
+
+
+        kwargs=@settings[:client]
+        if check.has_key?(:kwargs)
+          unless check[:kwargs].nil?
+            kwargs.merge!(check[:kwargs])
+          end
+        end
+        matched = find_client_attribute(kwargs, token.split('.'), default)
         if matched.nil?
           unmatched_tokens << token
         end


### PR DESCRIPTION
This is related with the issue #864 . Requirement description is defined there.

By the changes, it is support to send parameters on check execution. Here is its example of use;

This is check config;

``` json
{
  "checks": {
    "cron_check": {
      "handlers": ["default"],
      "command": "/etc/sensu/plugins/check-procs.rb -u :::user:::",
      "subscribers": [ "test" ],
     "interval": 60
    }
  }
}
```

It will result process check running under a user. Without my changes, to make it work, you should define `user` variable in your `client config`. But, what if you want to send some parameter to API with `/request` path on check execution. You couldn't do it.

Now, it can be done from API like;

``` json
{
    "check": "cron_check",
    "subscribers": ["test"],
    "kwargs":{
          "user":"ahmetdal"
     }
}
```

The process check script will now work with `ahmetdal` user. What if there is another variable with same name in client config. There is merging operation for `kwargs` coming from API and `client config`. `kwargs` prior than client config and it will override if same thing exists in `client config`
