### PR TITLE
allow reconnect on failure if required

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -158,7 +158,11 @@ module Sensu
         @logger.fatal('redis connection error', {
           :error => error.to_s
         })
-        stop
+        if @settings[:redis][:reconnect_on_error]
+          @redis.close
+        else
+          stop
+        end
       end
       @redis.before_reconnect do
         unless testing?


### PR DESCRIPTION
When using AWS ElastiCache as a HA redis alternative sensu-server will shutdown when a read-slave is promoted as an error is received which causes `stop` to be called. This patch allows, if required, for the redis connection to closed so it can cleanly reconnect to the newly promoted redis master 