### PR TITLE
Fix occurrences count & reference original event.

### DIFF
--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -144,18 +144,27 @@ describe "Sensu::Server::Process" do
           redis.set("client:i-424242", MultiJson.dump(client)) do
             result = result_template
             transport.publish(:direct, "results", MultiJson.dump(result))
-            transport.publish(:direct, "results", MultiJson.dump(result))
             timer(3) do
               redis.hget("events:i-424242", "test") do |event_json|
                 event = MultiJson.load(event_json)
                 expect(event[:id]).to be_kind_of(String)
                 expect(event[:first_id]).to be_kind_of(String)
-                expect(event[:check][:status]).to eq(1)
-                expect(event[:occurrences]).to eq(2)
-                timer(2) do
-                  latest_event_file = IO.read("/tmp/sensu-event.json")
-                  expect(MultiJson.load(latest_event_file)).to eq(event)
-                  async_done
+                expect(event[:occurrences]).to eq(1)
+                expect(event[:first_id]).to eq(event[:id])
+              end
+              transport.publish(:direct, "results", MultiJson.dump(result))
+              timer(3) do
+                redis.hget("events:i-424242", "test") do |event_json|
+                  event = MultiJson.load(event_json)
+                  expect(event[:id]).to be_kind_of(String)
+                  expect(event[:first_id]).to be_kind_of(String)
+                  expect(event[:check][:status]).to eq(1)
+                  expect(event[:occurrences]).to eq(2)
+                  timer(2) do
+                    latest_event_file = IO.read("/tmp/sensu-event.json")
+                    expect(MultiJson.load(latest_event_file)).to eq(event)
+                    async_done
+                  end
                 end
               end
             end

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -138,6 +138,7 @@ describe "Sensu::Server::Process" do
       @server.setup_transport
       @server.setup_redis
       @server.setup_results
+      first_id = ''
       redis.flushdb do
         timer(1) do
           client = client_template
@@ -148,9 +149,10 @@ describe "Sensu::Server::Process" do
               redis.hget("events:i-424242", "test") do |event_json|
                 event = MultiJson.load(event_json)
                 expect(event[:id]).to be_kind_of(String)
-                expect(event[:first_id]).to be_kind_of(String)
                 expect(event[:occurrences]).to eq(1)
+                expect(event[:first_id]).to be_kind_of(String)
                 expect(event[:first_id]).to eq(event[:id])
+                first_id = event[:first_id]
               end
               transport.publish(:direct, "results", MultiJson.dump(result))
               timer(3) do
@@ -158,6 +160,7 @@ describe "Sensu::Server::Process" do
                   event = MultiJson.load(event_json)
                   expect(event[:id]).to be_kind_of(String)
                   expect(event[:first_id]).to be_kind_of(String)
+                  expect(event[:first_id]).to eq(first_id)
                   expect(event[:check][:status]).to eq(1)
                   expect(event[:occurrences]).to eq(2)
                   timer(2) do

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -149,6 +149,7 @@ describe "Sensu::Server::Process" do
               redis.hget("events:i-424242", "test") do |event_json|
                 event = MultiJson.load(event_json)
                 expect(event[:id]).to be_kind_of(String)
+                expect(event[:first_id]).to be_kind_of(String)
                 expect(event[:check][:status]).to eq(1)
                 expect(event[:occurrences]).to eq(2)
                 timer(2) do


### PR DESCRIPTION
Change handling of event occurrences so that the count is only reset on an OK event: If an event is flapping between states and no flapping thresholds have been set its possible for it to never pass the occurrences threshold for the event to be handled. This will now continually increment occurrences so long as the check is reporting events without an OK status.

Additionally, added `:first_id` to the event data which will always contain the `:id` of the first event in this series of events, and kept so long as the events are not reporting OK or check is in a flapping state. This can be useful to help reference a batch of events, for example by using the `:id` and `:first_id` in the `Message-ID` or `In-Reply-To` headers of e-mails.