### PR TITLE
Enable reconnect on failure for Transport.

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -184,7 +184,11 @@ module Sensu
       @transport = Transport.connect(transport_name, transport_settings)
       @transport.on_error do |error|
         @logger.fatal("transport connection error", :error => error.to_s)
-        stop
+        if @settings[:transport][:reconnect_on_error]
+          @transport.reconnect
+        else
+          stop
+        end
       end
       @transport.before_reconnect do
         unless testing?


### PR DESCRIPTION
If the `server-server` service restarts, the channel is closed in RabbitMQ causing a failure in `sensu-api` which calls `stop`. This will (if configured) allow `sensu-api` to attempt a reconnection and continue rather than simply fail and abort (which will in turn affect event handling and Uchiwa).