### PR TITLE
Parameterized check extensions

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -173,14 +173,26 @@ module Sensu
       # VM and the EventMachine event loop, using the Sensu Extension
       # API.
       #
+      # If the check hash has an "extension" key, it will run the
+      # extension whose name that is the value of that key and 
+      # pass the check hash as an argument to safe_run(). 
+      # Otherwise, it will run the extension whose name that 
+      # is the value of the "name" key and pass nil to safe_run().
+      #
       # https://github.com/sensu/sensu-extension
       #
       # @param check [Hash]
       def run_check_extension(check)
         @logger.debug("attempting to run check extension", :check => check)
+        if check.has_key?(:extension) and @extensions[:checks].has_key?(check[:extension])
+          extension = @extensions[:checks][check[:extension]]
+          config = check
+        else
+          extension = @extensions[:checks][check[:name]]
+          config = nil
+        end
         check[:executed] = Time.now.to_i
-        extension = @extensions[:checks][check[:name]]
-        extension.safe_run do |output, status|
+        extension.safe_run(config) do |output, status|
           check[:output] = output
           check[:status] = status
           publish_check_result(check)
@@ -188,10 +200,12 @@ module Sensu
       end
 
       # Process a check request. If a check request has a check
-      # command, it will be executed. A check request without a check
-      # command indicates a check extension run. A check request will
-      # be merged with a local check definition, if present. Client
-      # safe mode is enforced in this method, requiring a local check
+      # command, it will be executed. If a check request has an extension
+      # name as the value of its "extension" key, run the extension passing
+      # through the check request. A check request without a check
+      # command or "extension" key indicates a check extension run. 
+      # A check request will be merged with a local check definition, if present.
+      # Client safe mode is enforced in this method, requiring a local check
       # definition in order to execute the check command. If a local
       # check definition does not exist when operating with client
       # safe mode, a check result will be published to report the
@@ -212,6 +226,10 @@ module Sensu
             publish_check_result(check)
           else
             execute_check_command(check)
+          end
+        elsif check.has_key?(:extension)
+          if @extensions.check_exists?(check[:extension])
+            run_check_extension(check)
           end
         else
           if @extensions.check_exists?(check[:name])

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -221,10 +221,8 @@ module Sensu
           else
             execute_check_command(check)
           end
-        elsif @extensions.check_exists?(check[:extension])
-          run_check_extension(check)
         else
-          if @extensions.check_exists?(check[:name])
+          if @extensions.check_exists?(check[:extension]) || @extensions.check_exists?(check[:name])
             run_check_extension(check)
           else
             @logger.warn("unknown check extension", :check => check)

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -184,15 +184,9 @@ module Sensu
       # @param check [Hash]
       def run_check_extension(check)
         @logger.debug("attempting to run check extension", :check => check)
-        if check.has_key?(:extension) and @extensions[:checks].has_key?(check[:extension])
-          extension = @extensions[:checks][check[:extension]]
-          config = check
-        else
-          extension = @extensions[:checks][check[:name]]
-          config = nil
-        end
         check[:executed] = Time.now.to_i
-        extension.safe_run(config) do |output, status|
+        extension = @extensions[:checks][check[:extension]] || @extensions[:checks][check[:name]]
+        extension.safe_run(check) do |output, status|
           check[:output] = output
           check[:status] = status
           publish_check_result(check)
@@ -227,10 +221,8 @@ module Sensu
           else
             execute_check_command(check)
           end
-        elsif check.has_key?(:extension)
-          if @extensions.check_exists?(check[:extension])
-            run_check_extension(check)
-          end
+        elsif @extensions.check_exists?(check[:extension])
+          run_check_extension(check)
         else
           if @extensions.check_exists?(check[:name])
             run_check_extension(check)


### PR DESCRIPTION
This adds support for checks which have no 'command' key, but have an 'extension' key. Such check requests will run the extension whose name is the value of the 'extension' key. The check request hash will be passed through to the run() method of the extension.

This is intended to fix https://github.com/sensu/sensu/issues/866. See the comments on that issue for the rationale behind these changes, and the pattern of check extensions for which this is intended to add support.

This PR requires an changes to sensu-settings, which will be forthcoming in another PR.

One note: A local ```rake spec``` run showed many failures. This could just be an error with my build environment -- I see those failures when running it against ```master``` as well. We'll see if the tests pass in Travis :)