### PR TITLE
Fix for incorrect key to lookup :reconnect_on_error option.

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -184,7 +184,7 @@ module Sensu
       @transport = Transport.connect(transport_name, transport_settings)
       @transport.on_error do |error|
         @logger.fatal("transport connection error", :error => error.to_s)
-        if @settings[:transport][:reconnect_on_error]
+        if @settings[transport_name][:reconnect_on_error]
           @transport.reconnect
         else
           stop


### PR DESCRIPTION
I put the incorrect key in for the transport name. This setting will allow the value to be included with the rest of the configuration for the transport (i.e. within rabbitmq's settings). Found when trying to expand Puppet configuration to support.