### PR TITLE
add extensiona and opts to check payload

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -412,7 +412,6 @@ module Sensu
         }
         payload[:command] = check[:command] if check.has_key?(:command)
         payload[:extension] = check[:extension] if check.has_key?(:extension)
-        payload[:extension_opts] = check[:extension_opts] if check.has_key?(:extension_opts)
 
         @logger.info("publishing check request", {
           :payload => payload,

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -412,7 +412,6 @@ module Sensu
         }
         payload[:command] = check[:command] if check.has_key?(:command)
         payload[:extension] = check[:extension] if check.has_key?(:extension)
-
         @logger.info("publishing check request", {
           :payload => payload,
           :subscribers => check[:subscribers]

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -411,6 +411,9 @@ module Sensu
           :issued => Time.now.to_i
         }
         payload[:command] = check[:command] if check.has_key?(:command)
+        payload[:extension] = check[:extension] if check.has_key?(:extension)
+        payload[:extension_opts] = check[:extension_opts] if check.has_key?(:extension_opts)
+
         @logger.info("publishing check request", {
           :payload => payload,
           :subscribers => check[:subscribers]


### PR DESCRIPTION
Patch to go with https://github.com/sensu/sensu/pull/889

The server only sends check name and issued time to the clients.
This PR adds extension name and extension_opts if they exist.

@rmc3 I've used the format from your check example. Have you already solved this exact problem or are you using the checks in standalone mode?