### PR TITLE
Change gemspec to allow newer eventmachines, fixes ruby 2.2

### DIFF
--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json" if RUBY_VERSION < "1.9"
   s.add_dependency "multi_json", "1.11.0"
   s.add_dependency "uuidtools", "2.1.4"
-  s.add_dependency "eventmachine", "1.0.3"
+  s.add_dependency "eventmachine", "~>1.0", ">=1.0.3"
   s.add_dependency "sensu-em", "2.4.1"
   s.add_dependency "sensu-logger", "1.0.0"
   s.add_dependency "sensu-settings", "1.3.0"


### PR DESCRIPTION
Less invasive gemspec change to allow eventmachine >1.0.3 for ruby 2.2, but still allow eventmachine 1.0.3 for windows if required. Replaces #905