### PR TITLE
Implement aggregate grouping

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -218,6 +218,7 @@ module Sensu
         result_key = "#{client[:name]}:#{check[:name]}"
         history_key = "history:#{result_key}"
         @redis.rpush(history_key, check[:status]) do
+          @redis.set("execution:#{result_key}", check[:executed])
           @redis.ltrim(history_key, -21, -1)
           callback.call
         end
@@ -366,11 +367,6 @@ module Sensu
                 end
               end
             end
-            @logger.debug("updating result data", :check=> check)
-            result_truncated_output = result.dup
-            result_truncated_output[:check][:output] = check[:output][0..256]
-            @redis.set("result:#{client[:name]}:#{check[:name]}", MultiJson.dump(result_truncated_output))
-            @redis.sadd('results', "#{client[:name]}:#{check[:name]}")
           else
             @logger.warn("client not in registry", :client => result[:client])
           end

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -499,7 +499,7 @@ module Sensu
             check_requests[aggregate_group][check[:interval]] ||= []
             check_requests[aggregate_group][check[:interval]].push(check)
           else
-            schedule_check_execution(check_name, interval, Proc.new { publish_check_request(check) })
+            schedule_check_execution(check[:name], interval, Proc.new { publish_check_request(check) })
           end
         end
         check_requests.each do |group, intervals|

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -170,8 +170,11 @@ module Sensu
       end
 
       # Add a check result to an aggregate. A check aggregate uses the
-      # check `:name` and the `:issued` timestamp as its unique
-      # identifier. An aggregate uses several counters: the total
+      # check name and the `:issued` timestamp as its unique
+      # identifier. It's possible to supply an Array of names to
+      # override `check[:name]` to store check results in multiple
+      # aggregate buckets or to group checks with different check-names.
+      # An aggregate uses several counters: the total
       # number of results in the aggregate, and a counter for each
       # check severity (ok, warning, etc). Check output is also
       # stored, to be summarized to aid in identifying outliers for a
@@ -182,17 +185,21 @@ module Sensu
       def aggregate_check_result(result)
         @logger.debug("adding check result to aggregate", :result => result)
         check = result[:check]
-        result_set = "#{check[:name]}:#{check[:issued]}"
-        result_data = MultiJson.dump(:output => check[:output], :status => check[:status])
-        @redis.hset("aggregation:#{result_set}", result[:client], result_data) do
-          SEVERITIES.each do |severity|
-            @redis.hsetnx("aggregate:#{result_set}", severity, 0)
-          end
-          severity = (SEVERITIES[check[:status]] || "unknown")
-          @redis.hincrby("aggregate:#{result_set}", severity, 1) do
-            @redis.hincrby("aggregate:#{result_set}", "total", 1) do
-              @redis.sadd("aggregates:#{check[:name]}", check[:issued]) do
-                @redis.sadd("aggregates", check[:name])
+        aggregate_groups = check[:aggregate].is_a?(Array) ? \
+          check[:aggregate].map { |aggregate_group_name| aggregate_group_name } : [ check[:name] ]
+        aggregate_groups.each do |check_name|
+	        result_set = "#{check_name}:#{check[:issued]}"
+          result_data = MultiJson.dump(:output => check[:output], :status => check[:status])
+          @redis.hset("aggregation:#{result_set}", result[:client], result_data) do
+            SEVERITIES.each do |severity|
+              @redis.hsetnx("aggregate:#{result_set}", severity, 0)
+            end
+            severity = (SEVERITIES[check[:status]] || "unknown")
+            @redis.hincrby("aggregate:#{result_set}", severity, 1) do
+              @redis.hincrby("aggregate:#{result_set}", "total", 1) do
+                @redis.sadd("aggregates:#{check_name}", check[:issued]) do
+                  @redis.sadd("aggregates", check_name)
+                end
               end
             end
           end

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -188,7 +188,7 @@ module Sensu
         aggregate_groups = check[:aggregate].is_a?(Array) ? \
           check[:aggregate].map { |aggregate_group_name| aggregate_group_name } : [ check[:name] ]
         aggregate_groups.each do |check_name|
-	        result_set = "#{check_name}:#{check[:issued]}"
+          result_set = "#{check_name}:#{check[:issued]}"
           result_data = MultiJson.dump(:output => check[:output], :status => check[:status])
           @redis.hset("aggregation:#{result_set}", result[:client], result_data) do
             SEVERITIES.each do |severity|

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -499,7 +499,7 @@ module Sensu
             check_requests[aggregate_group][check[:interval]] ||= []
             check_requests[aggregate_group][check[:interval]].push(check)
           else
-            schedule_check_execution(check[:name], interval, Proc.new { publish_check_request(check) })
+            schedule_check_execution(check[:name], check[:interval], Proc.new { publish_check_request(check) })
           end
         end
         check_requests.each do |group, intervals|

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -186,7 +186,7 @@ module Sensu
         @logger.debug("adding check result to aggregate", :result => result)
         check = result[:check]
         check_name = check[:aggregate].is_a?(String) ? check[:aggregate] : check[:name]
-	result_set = "#{check_name}:#{check[:issued]}"
+        result_set = "#{check_name}:#{check[:issued]}"
         result_data = MultiJson.dump(:output => check[:output], :status => check[:status])
         @redis.hset("aggregation:#{result_set}", result[:client], result_data) do
           SEVERITIES.each do |severity|
@@ -415,15 +415,13 @@ module Sensu
       # @param check [Hash] definition.
       def publish_check_request(check, issued = nil)
         issued = Time.now.to_i unless issued
-
         if check_request_subdued?(check)
           @logger.info("check request was subdued", :check => check)
-          return 
+          return
         end
-
         payload = {
           :name => check[:name],
-          :issued => issued 
+          :issued => issued
         }
         payload[:command] = check[:command] if check.has_key?(:command)
         @logger.info("publishing check request", {
@@ -445,7 +443,6 @@ module Sensu
 
       def publish_check_requests(checks)
         issued = Time.now.to_i
-
         checks.each do |check|
           publish_check_request(check, issued)
         end
@@ -493,7 +490,7 @@ module Sensu
         end
         check_requests.each do |group, intervals|
           intervals.each do |interval, checks|
-            add_check_request_to_scheduler(group, interval, 
+            add_check_request_to_scheduler(group, interval,
               Proc.new { publish_check_requests(checks) })
           end
         end

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -186,9 +186,9 @@ describe "Sensu::Server::Process" do
     allow(Time).to receive(:now).and_return("1414213569.032")
     check = check_template
     check[:interval] = 60
-    expect(@server.calculate_check_execution_splay(check)).to eq(17.601)
+    expect(@server.calculate_check_execution_splay(check[:name], check[:interval])).to eq(17.601)
     check[:interval] = 3600
-    expect(@server.calculate_check_execution_splay(check)).to eq(3497.601)
+    expect(@server.calculate_check_execution_splay(check[:name], check[:interval])).to eq(3497.601)
   end
 
   it "can schedule check request publishing" do


### PR DESCRIPTION
My use case is that I have multiple instances of various apps deployed to a single machine and monitored by a single sensu-client.

It's not possible to have duplicate check definitions with the same name so I've include a unique identifier in each check name, e.g: `fooapp-id-check_for_process`. When I add `aggregate: true` to my metadata, this results in the checks being written to separate buckets and not being aggregated properly.

This change allows you to specify an array of virtual check names to `aggregate:` enabling you to group checks into different (and multiple) buckets.

This builds upon the current effect of the `aggregate:` parameter and won't break existing check configs.