### PR TITLE
Make use of the Redis reconnect_on_error setting

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -212,7 +212,11 @@ module Sensu
       @redis = Redis.connect(@settings[:redis])
       @redis.on_error do |error|
         @logger.fatal("redis connection error", :error => error.to_s)
-        stop
+        if @settings[:redis][:reconnect_on_error]
+          @redis.close
+        else
+          stop
+        end
       end
       @redis.before_reconnect do
         unless testing?


### PR DESCRIPTION
The `setup_redis` function was not making use of the `reconnect_on_error` setting as the `setup_transport` function does.