### PR TITLE
allow filters to be defined in a check

### DIFF
--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -257,8 +257,8 @@ module Sensu
       # @param event [Hash]
       # @param callback [Proc]
       def event_filtered?(handler, event, &callback)
-        if handler.has_key?(:filters) || handler.has_key?(:filter)
-          filter_list = Array(handler[:filters] || handler[:filter])
+        if handler.key?(:filters) || handler.key?(:filter) || event[:client].key?(:filter) || event[:client].key?(:filters)
+          filter_list = Array(handler[:filters] || handler[:filter] || event[:client][:filter] || event[:client][:filters])
           filter_results = EM::Iterator.new(filter_list)
           run_filters = Proc.new do |filter_name, iterator|
             event_filter(filter_name, event) do |filtered|


### PR DESCRIPTION
option to set filters in the check.

Some checks require variable levels of handling, and at the moment, a new handler need to be created for each filter variation, for example:

pagerduty_notify_instantly
pagerduty_notify_after_5_failed_attempts
pagerduty_notify_after_10_failed_attempts

Say I have a single check that i want to only notify after 5 failed attempts, but all others must notify instantly when critical.

this results in having handlers like:

pagerduty_notify_instantly
pagerduty_notify_after_5_failed_attempts
pagerduty_notify_after_10_failed_attempts

it would be simpler to have 1 handler, and simply define the filter inside the specific check that needs it.