### PR TITLE
Enable external resource monitoring

### DIFF
--- a/lib/sensu/api/process.rb
+++ b/lib/sensu/api/process.rb
@@ -352,7 +352,7 @@ module Sensu
 
       aget %r{/clients/([\w\.-]+)/history/?$} do |client_name|
         response = Array.new
-        settings.redis.smembers("history:#{client_name}") do |checks|
+        settings.redis.smembers("result:#{client_name}") do |checks|
           unless checks.empty?
             checks.each_with_index do |check_name, index|
               result_key = "#{client_name}:#{check_name}"

--- a/lib/sensu/api/process.rb
+++ b/lib/sensu/api/process.rb
@@ -170,7 +170,9 @@ module Sensu
           begin
             data = MultiJson.load(env["rack.input"].read)
             valid = rules.all? do |key, rule|
-              data[key].is_a?(rule[:type]) || (rule[:nil_ok] && data[key].nil?)
+              value = data[key]
+              (value.is_a?(rule[:type]) || (rule[:nil_ok] && value.nil?)) &&
+                rule[:regex].nil? || (rule[:regex] && (value =~ rule[:regex]) == 0)
             end
             if valid
               callback.call(data)
@@ -302,6 +304,23 @@ module Sensu
         end
       end
 
+      apost "/clients/?" do
+        rules = {
+          :name => {:type => String, :nil_ok => false, :regex => /^[\w\.-]+$/},
+          :address => {:type => String, :nil_ok => false},
+          :subscriptions => {:type => Array, :nil_ok => false}
+        }
+        read_data(rules) do |data|
+          data[:keepalives] = false
+          data[:timestamp] = Time.now.to_i
+          settings.redis.set("client:#{data[:name]}", MultiJson.dump(data)) do
+            settings.redis.sadd("clients", data[:name]) do
+              created!(MultiJson.dump(:name => data[:name]))
+            end
+          end
+        end
+      end
+
       aget "/clients/?" do
         response = Array.new
         settings.redis.smembers("clients") do |clients|
@@ -430,7 +449,7 @@ module Sensu
               :subscribers => subscribers
             })
             subscribers.uniq.each do |exchange_name|
-              settings.transport.publish(:fanout, exchange_name, MultiJson.dump(payload)) do |info|
+              settings.transport.publish(:fanout, exchange_name.to_s, MultiJson.dump(payload)) do |info|
                 if info[:error]
                   settings.logger.error("failed to publish check request", {
                     :exchange_name => exchange_name,

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "multi_json", "1.11.0"
 
 gem "sensu-em", "2.4.1"
 gem "sensu-logger", "1.0.0"
-gem "sensu-settings", "1.3.0"
+gem "sensu-settings", "1.4.0"
 gem "sensu-extension", "1.1.2"
 gem "sensu-extensions", "1.2.0"
 gem "sensu-transport", "2.4.0"

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -352,7 +352,7 @@ module Sensu
           :subscriptions => [],
           :keepalives => false
         }
-        update_client_registry(client, callback)
+        update_client_registry(client, &callback)
       end
 
       # Retrieve a client (data) from Redis if it exists. If a client
@@ -370,7 +370,7 @@ module Sensu
             client = MultiJson.load(client_json)
             callback.call(client)
           else
-            create_client(client_key, callback)
+            create_client(client_key, &callback)
           end
         end
       end

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -586,6 +586,7 @@ module Sensu
             @redis.get("client:#{client_name}") do |client_json|
               unless client_json.nil?
                 client = MultiJson.load(client_json)
+                next if client[:keepalives] == false
                 check = create_keepalive_check(client)
                 time_since_last_keepalive = Time.now.to_i - client[:timestamp]
                 check[:output] = "No keepalive sent from client for "

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -49,7 +49,7 @@ module Sensu
         @logger.debug("updating client registry", :client => client)
         @redis.set("client:#{client[:name]}", MultiJson.dump(client)) do
           @redis.sadd("clients", client[:name]) do
-            callback.call
+            callback.call(client)
           end
         end
       end
@@ -335,39 +335,73 @@ module Sensu
         end
       end
 
+      # Create a blank client (data) and add it to the client
+      # registry. Only the client name is known, the other client
+      # attributes must be updated via the API (POST /clients:client).
+      # Dynamically created clients and those updated via the API will
+      # have client keepalives disabled, `:keepalives` is set to
+      # `false`.
+      #
+      # @param name [Hash] to use for the client.
+      # @param callback [Proc] to be called with the dynamically
+      # created client data.
+      def create_client(name, &callback)
+        client = {
+          :name => name,
+          :address => "unknown",
+          :subscriptions => [],
+          :keepalives => false
+        }
+        update_client_registry(client, callback)
+      end
+
+      # Retrieve a client (data) from Redis if it exists. If a client
+      # does not already exist, create one (a blank) using the
+      # `client_key` as the client name. Dynamically create client
+      # data can be updated using the API (POST /clients/:client).
+      #
+      # @param result [Hash] data.
+      # @param callback [Proc] to be called with client data, either
+      #   retrieved from Redis, or dynamically created.
+      def retrieve_client(result, &callback)
+        client_key = result[:check][:source] || result[:client]
+        @redis.get("client:#{client_key}") do |client_json|
+          unless client_json.nil?
+            client = MultiJson.load(client_json)
+            callback.call(client)
+          else
+            create_client(client_key, callback)
+          end
+        end
+      end
+
       # Process a check result, storing its data, inspecting its
       # contents, and taking the appropriate actions (eg. update the
       # event registry). A check result must have a valid client name,
-      # associated with a client in the registry. Results without a
-      # valid client are discarded, to keep the system "correct". If a
-      # local check definition exists for the check name, and the
-      # check result is not from a standalone check execution, it's
-      # merged with the check result for more context.
+      # associated with a client in the registry or one will be
+      # created. If a local check definition exists for the check
+      # name, and the check result is not from a standalone check
+      # execution, it's merged with the check result for more context.
       #
       # @param result [Hash] data.
       def process_check_result(result)
         @logger.debug("processing result", :result => result)
-        @redis.get("client:#{result[:client]}") do |client_json|
-          unless client_json.nil?
-            client = MultiJson.load(client_json)
-            check = case
-            when @settings.check_exists?(result[:check][:name]) && !result[:check][:standalone]
-              @settings[:checks][result[:check][:name]].merge(result[:check])
-            else
-              result[:check]
-            end
-            aggregate_check_result(result) if check[:aggregate]
-            store_check_result(client, check) do
-              check_history(client, check) do |history, total_state_change|
-                check[:history] = history
-                check[:total_state_change] = total_state_change
-                update_event_registry(client, check) do |event|
-                  process_event(event)
-                end
+        retrieve_client(result) do |client|
+          check = case
+          when @settings.check_exists?(result[:check][:name]) && !result[:check][:standalone]
+            @settings[:checks][result[:check][:name]].merge(result[:check])
+          else
+            result[:check]
+          end
+          aggregate_check_result(result) if check[:aggregate]
+          store_check_result(client, check) do
+            check_history(client, check) do |history, total_state_change|
+              check[:history] = history
+              check[:total_state_change] = total_state_change
+              update_event_registry(client, check) do |event|
+                process_event(event)
               end
             end
-          else
-            @logger.warn("client not in registry", :client => result[:client])
           end
         end
       end

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -344,7 +344,7 @@ module Sensu
       #
       # @param name [Hash] to use for the client.
       # @param callback [Proc] to be called with the dynamically
-      # created client data.
+      #   created client data.
       def create_client(name, &callback)
         client = {
           :name => name,

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.0.3"
   s.add_dependency "sensu-em", "2.4.1"
   s.add_dependency "sensu-logger", "1.0.0"
-  s.add_dependency "sensu-settings", "1.3.0"
+  s.add_dependency "sensu-settings", "1.4.0"
   s.add_dependency "sensu-extension", "1.1.2"
   s.add_dependency "sensu-extensions", "1.2.0"
   s.add_dependency "sensu-transport", "2.4.0"

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -97,6 +97,59 @@ describe 'Sensu::API::Process' do
     end
   end
 
+  it 'can create a client' do
+    api_test do
+      options = {
+        :body => {
+          :name => 'i-888888',
+          :address => '8.8.8.8',
+          :subscriptions => [
+            'test'
+          ]
+        }
+      }
+      api_request('/clients', :post, options) do |http, body|
+        expect(http.response_header.status).to eq(201)
+        expect(body).to be_kind_of(Hash)
+        expect(body[:name]).to eq('i-888888')
+        async_done
+      end
+    end
+  end
+
+  it 'can not create a client with an invalid post body' do
+    api_test do
+      options = {
+        :body => {
+          :name => 'i-424242',
+          :address => '8.8.8.8',
+          :subscriptions => [
+            'test'
+          ]
+        }
+      }
+      invalid_name = options.dup
+      invalid_name[:body][:name] = 'i-$$$$$$'
+      missing_address = options.dup
+      missing_address[:body].delete(:address)
+      invalid_subscriptions = options.dup
+      invalid_subscriptions[:body][:subscriptions] = "invalid"
+      api_request('/clients', :post, invalid_name) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        api_request('/clients', :post, missing_address) do |http, body|
+          expect(http.response_header.status).to eq(400)
+          api_request('/clients', :post, invalid_subscriptions) do |http, body|
+            expect(http.response_header.status).to eq(400)
+            api_request('/clients', :post) do |http, body|
+              expect(http.response_header.status).to eq(400)
+              async_done
+            end
+          end
+        end
+      end
+    end
+  end
+
   it 'can provide current clients' do
     api_test do
       api_request('/clients') do |http, body|
@@ -268,6 +321,35 @@ describe 'Sensu::API::Process' do
     end
   end
 
+  it 'can create and provide a client' do
+    api_test do
+      options = {
+        :body => {
+          :name => 'i-888888',
+          :address => '8.8.8.8',
+          :subscriptions => [
+            'test'
+          ]
+        }
+      }
+      api_request('/clients', :post, options) do |http, body|
+        expect(http.response_header.status).to eq(201)
+        expect(body).to be_kind_of(Hash)
+        expect(body[:name]).to eq('i-888888')
+        api_request('/client/i-888888') do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Hash)
+          expect(body[:name]).to eq('i-888888')
+          expect(body[:address]).to eq('8.8.8.8')
+          expect(body[:subscriptions]).to eq(['test'])
+          expect(body[:keepalives]).to be(false)
+          expect(body[:timestamp]).to be_within(10).of(epoch)
+          async_done
+        end
+      end
+    end
+  end
+
   it 'can not provide a nonexistent client' do
     api_test do
       api_request('/client/nonexistent') do |http, body|
@@ -343,7 +425,8 @@ describe 'Sensu::API::Process' do
         :body => {
           :check => 'tokens',
           :subscribers => [
-            'test'
+            'test',
+            1
           ]
         }
       }

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -19,7 +19,7 @@ describe 'Sensu::API::Process' do
                 redis.set('stash:test/test', '{"key": "value"}') do
                   redis.expire('stash:test/test', 3600) do
                     redis.sadd('stashes', 'test/test') do
-                      redis.sadd('history:i-424242', 'test') do
+                      redis.sadd('result:i-424242', 'test') do
                         redis.rpush('history:i-424242:test', 0) do
                           @redis = nil
                           async_done

--- a/spec/config.json
+++ b/spec/config.json
@@ -126,10 +126,20 @@
       "command": "this will be overwritten",
       "interval": 60
     },
+    "source": {
+      "source": "switch-y",
+      "command": "/bin/true",
+      "subscribers": [
+        "test"
+      ],
+      "interval": 1
+    },
     "unpublished": {
       "command": "/bin/true",
       "publish": false,
-      "subscribers":["test"]
+      "subscribers": [
+        "test"
+      ]
     }
   },
   "client": {

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -230,7 +230,7 @@ describe "Sensu::Server::Process" do
 
   it "can schedule check request publishing" do
     async_wrapper do
-      expected = ["tokens", "merger", "sensu_cpu_time"]
+      expected = ["tokens", "merger", "sensu_cpu_time", "source"]
       transport.subscribe(:fanout, "test") do |_, payload|
         check_request = MultiJson.load(payload)
         expect(check_request[:issued]).to be_within(10).of(epoch)

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -145,7 +145,7 @@ describe "Sensu::Server::Process" do
             result = result_template
             transport.publish(:direct, "results", MultiJson.dump(result))
             transport.publish(:direct, "results", MultiJson.dump(result))
-            timer(3) do
+            timer(4) do
               redis.sismember("result:i-424242", "test") do |is_member|
                 expect(is_member).to be(true)
                 redis.get("result:i-424242:test") do |result_json|


### PR DESCRIPTION
Possible solution for https://github.com/sensu/sensu/issues/541

https://trello.com/c/eowfiJQ8/21-as-an-operator-i-would-like-to-monitor-external-resources-that-do-not-have-sensu-client-they-require-their-own-check-execution-h