### PR TITLE
Round-robin subscriptions

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -236,7 +236,7 @@ module Sensu
       # Determine the Sensu transport subscribe options for a
       # subscription. If a subscription begins with a transport pipe
       # type, either "direct:" or "roundrobin:", the subscription uses
-      # a direct transport pipe, and the subscription name is uses for
+      # a direct transport pipe, and the subscription name is used for
       # both the pipe and the funnel names. If a subscription does not
       # specify a transport pipe type, a fanout transport pipe is
       # used, the subscription name is used for the pipe, and a unique

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -31,13 +31,16 @@ module Sensu
   module Daemon
     include Utilities
 
-    # Initialize the Sensu process. Set the initial service state, set
-    # up the logger, load settings, load extensions, and optionally
-    # daemonize the process and/or create a PID file. A subclass may
-    # override this method.
+    attr_reader :start_time
+
+    # Initialize the Sensu process. Set the start time, initial
+    # service state, set up the logger, load settings, load
+    # extensions, and optionally daemonize the process and/or create a
+    # PID file. A subclass may override this method.
     #
     # @param options [Hash]
     def initialize(options={})
+      @start_time = Time.now.to_i
       @state = :initializing
       @timers = {:run => []}
       setup_logger(options)

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -436,6 +436,16 @@ module Sensu
         end
       end
 
+      # Determine the Sensu transport publish options for a
+      # subscription. If a subscription begins with a transport pipe
+      # type, either "direct:" or "roundrobin:", the subscription uses
+      # a direct transport pipe. If a subscription does not specify a
+      # transport pipe type, a fanout transport pipe is used.
+      #
+      # @param subscription [String]
+      # @return [Array] containing the transport publish options:
+      #   the transport pipe type, pipe, and the message to be
+      #   published.
       def transport_publish_options(subscription, message)
         _, raw_type = subscription.split(":", 2).reverse
         case raw_type

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -154,6 +154,25 @@ describe "Sensu::Client::Process" do
     end
   end
 
+  it "can receive a check request on a round-robin subscription" do
+    async_wrapper do
+      result_queue do |payload|
+        result = MultiJson.load(payload)
+        expect(result[:client]).to eq("i-424242")
+        expect(result[:check][:output]).to eq("WARNING\n")
+        expect(result[:check][:status]).to eq(1)
+        async_done
+      end
+      timer(0.5) do
+        @client.setup_transport
+        @client.setup_subscriptions
+        timer(1) do
+          transport.publish(:direct, "roundrobin:test", MultiJson.dump(check_template))
+        end
+      end
+    end
+  end
+
   it "can receive a check request and not execute the check due to safe mode" do
     async_wrapper do
       result_queue do |payload|

--- a/spec/config.json
+++ b/spec/config.json
@@ -132,6 +132,13 @@
       ],
       "interval": 1
     },
+    "roundrobin": {
+      "command": "/bin/true",
+      "subscribers": [
+        "roundrobin:test"
+      ],
+      "interval": 1
+    },
     "unpublished": {
       "command": "/bin/true",
       "publish": false,
@@ -144,7 +151,9 @@
     "name": "i-424242",
     "address": "127.0.0.1",
     "subscriptions": [
-      "test"
+      "test",
+      "roundrobin:test",
+      "all"
     ],
     "keepalive": {
       "thresholds": {

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -159,7 +159,7 @@ describe "Sensu::Server::Process" do
                     expect(event[:id]).to be_kind_of(String)
                     expect(event[:check][:status]).to eq(1)
                     expect(event[:occurrences]).to eq(2)
-                    timer(2) do
+                    timer(3) do
                       latest_event_file = IO.read("/tmp/sensu-event.json")
                       expect(MultiJson.load(latest_event_file)).to eq(event)
                       async_done

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -222,6 +222,24 @@ describe "Sensu::Server::Process" do
     end
   end
 
+  it "can publish check requests to round-robin subscriptions" do
+    async_wrapper do
+      transport.subscribe(:direct, "roundrobin:test") do |_, payload|
+        check_request = MultiJson.load(payload)
+        expect(check_request[:name]).to eq("test")
+        expect(check_request[:command]).to eq("echo WARNING && exit 1")
+        expect(check_request[:issued]).to be_within(10).of(epoch)
+        async_done
+      end
+      timer(0.5) do
+        @server.setup_transport
+        check = check_template
+        check[:subscribers] = ["roundrobin:test"]
+        @server.publish_check_request(check)
+      end
+    end
+  end
+
   it "can calculate a check execution splay interval" do
     allow(Time).to receive(:now).and_return("1414213569.032")
     check = check_template


### PR DESCRIPTION
This PR add support for round-robin client subscriptions, allowing a single client in a subscription to receive a check request (1:1 instead of 1:N).

Trello card: https://trello.com/c/5GN1GyXs/6-as-an-operator-i-would-like-to-have-a-check-request-go-to-a-single-subscriber-of-a-subscription