### PR TITLE
Make a checkttl expiration event always be critical

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -670,8 +670,8 @@ module Sensu
                     time_since_last_execution = Time.now.to_i - check[:executed]
                     if time_since_last_execution >= check[:ttl]
                       check[:output] = "Last check execution was "
-                      check[:output] << "#{time_since_last_execution} seconds ago"
-                      check[:status] = 1
+                      check[:output] << "#{time_since_last_execution} seconds ago. (Threshold: #{check[:ttl]} seconds)"
+                      check[:status] = 2
                       publish_check_result(client_name, check)
                     end
                   end

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -383,7 +383,7 @@ describe "Sensu::Server::Process" do
                     expect(events.size).to eq(1)
                     event = MultiJson.load(events["foo"])
                     expect(event[:check][:output]).to match(/Last check execution was 3[0-9] seconds ago/)
-                    expect(event[:check][:status]).to eq(1)
+                    expect(event[:check][:status]).to eq(2)
                     async_done
                   end
                 end


### PR DESCRIPTION
At yelp we never send warnings to our more critical handlers (pagerduty).

I want to be able to allow people to set a ttl on ephemeral checks and give them at least the option to page, but if it is alway set to warning, that can never happen?

I don't believe in warnings. :(


If you don't agree with this change, would you accept a more complicated PR that... set multiple thresholds like the keepalive thresholds? (but I would rather KISS here and have it set to always be crit)

cc @hashbrowncipher @bobtfish