### PR TITLE
Make force-resolving set a null TTL so that you can actually get rid of checks with ttls somehow

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -666,7 +666,7 @@ module Sensu
                 @redis.get("result:#{result_key}") do |result_json|
                   unless result_json.nil?
                     check = MultiJson.load(result_json)
-                    next unless check[:ttl] && check[:executed]
+                    next unless check[:ttl] && check[:executed] && !check[:force_resolve]
                     time_since_last_execution = Time.now.to_i - check[:executed]
                     if time_since_last_execution >= check[:ttl]
                       check[:output] = "Last check execution was "


### PR DESCRIPTION
The check ttl feature is the bomb.
But it needs *some way* to actually get rid of checks after you no longer want them.

The problem is: how do you let sensu know that you no longer want it to keep reminding you that it is failing? One way to do that is to set `ttl:null` in the manual resolve. (sensu-cli/uchiwa/etc)