### PR TITLE
log with debug level instead of info in filter_event

### DIFF
--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -296,14 +296,14 @@ module Sensu
           "handler is subdued"
         end
         if filter_message
-          @logger.info(filter_message, details)
+          @logger.debug(filter_message, details)
           @handling_event_count -= 1 if @handling_event_count
         else
           event_filtered?(handler, event) do |filtered|
             unless filtered
               callback.call(event)
             else
-              @logger.info("event was filtered", details)
+              @logger.debug("event was filtered", details)
               @handling_event_count -= 1 if @handling_event_count
             end
           end


### PR DESCRIPTION
When an event is filtered out and not sent to a handler, right now this gets logged at level=info. I think it could be better to log this with level=debug.

There are pros and cons to either approach, I was just wondering what people think.
