### PR TITLE
[clients] resolve inconsistent state in redis

### DIFF
--- a/lib/sensu/api/process.rb
+++ b/lib/sensu/api/process.rb
@@ -337,14 +337,18 @@ module Sensu
                 if client_json.nil?
                   settings.logger.error("redis returned nil for #{client_name}")
                   settings.redis.srem("clients", client_name)
-                  next
+                else
+                  response << MultiJson.load(client_json)
                 end
-                response << MultiJson.load(client_json)
+                if index == clients.size - 1
+                  body MultiJson.dump(response)
+                end
               end
             end
+          else
+            body MultiJson.dump(response)
           end
         end
-        body MultiJson.dump(response)
       end
 
       aget %r{^/clients?/([\w\.-]+)/?$} do |client_name|


### PR DESCRIPTION
I'm not sure exactly what can cause this state to occur, but it's
possible for sensu to have a client name in the clients list that does
not have a paired `client:` config.

When this happens, the api server restarts/crashes every time you hit
`/clients/`. And unfortunately you can't DELETE the client because `adelete` calls the exact same json.parse functionality as list does.

I'm not sure what the best way to handle this is, this definitely resolved the issue for me, but it seems plausible that much of `adelete` should be factored out into its own function so that we can delete all of the metadata around a partially inconsistent client.