### PR TITLE
Locking via API, wildcard results fetching

### DIFF
--- a/lib/sensu/api/process.rb
+++ b/lib/sensu/api/process.rb
@@ -800,8 +800,12 @@ module Sensu
         settings.redis.keys(keys) do |keys|
           if keys && keys.size > 0
             EM::Iterator.new(keys).map(
-              proc {|key, iter| settings.redis.get(key) {|data| iter.return(data) } },
-              proc {|responses| body MultiJson.dump(responses) }
+              lambda do |key, iter|
+                settings.redis.get(key) do |data|
+                  iter.return(key.split(':')[1] => data)
+                end
+              end,
+              lambda { |res| body MultiJson.dump(res.inject({}, &:merge)) }
             )
           else
             not_found!
@@ -810,22 +814,26 @@ module Sensu
       end
 
       aget %r{^/lock/([\w\.-]+)/([\w\.-]+)/(\d+)/?$} do |lock, new_holder, pttl|
-        settings.redis.setnx(lock, new_holder) do |ack|
-          if ack == 1
-            settings.redis.pttl(lock, pttl) do
-              created! now
+        lock_key = "lock:#{lock}"
+        settings.redis.setnx(lock_key, new_holder) do |ack|
+          if ack
+            settings.redis.pexpire(lock_key, pttl.to_i) do
+              created! MultiJson.dump(:lock      => lock,
+                                      :holder    => new_holder,
+                                      :pttl      => pttl,
+                                      :timestamp => Time.now.to_f)
             end
           else
-            settings.redis.get(lock) do |holder|
+            settings.redis.get(lock_key) do |holder|
               if holder
-                settings.redis.pttl(lock) do |pttl_left|
+                settings.redis.pttl(lock_key) do |pttl_left|
                   # possibly expired between .get and .pttl
-                  body MultiJson.dump(:holder => holder, :pttl => pttl_left)
+                  # body MultiJson.dump(:holder => holder, :pttl => pttl_left)
                   not_found!
                 end
               else
                 # expired between .setnx and .get
-                body MultiJson.dump(:holder => nil)
+                # body MultiJson.dump(:holder => nil)
                 not_found!
               end
             end

--- a/lib/sensu/api/process.rb
+++ b/lib/sensu/api/process.rb
@@ -798,18 +798,14 @@ module Sensu
       aget %r{^/results?/\*/([\w\.-]+)/?$} do |check_name|
         keys = "result:*:#{check_name}"
         settings.redis.keys(keys) do |keys|
-          if keys && keys.size > 0
-            EM::Iterator.new(keys).map(
-              lambda do |key, iter|
-                settings.redis.get(key) do |data|
-                  iter.return(key.split(':')[1] => data)
-                end
-              end,
-              lambda { |res| body MultiJson.dump(res.inject({}, &:merge)) }
-            )
-          else
-            not_found!
-          end
+          EM::Iterator.new(keys).map(
+            lambda do |key, iter|
+              settings.redis.get(key) do |data|
+                iter.return(key.split(':')[1] => data)
+              end
+            end,
+            lambda { |res| body MultiJson.dump(res.inject({}, &:merge)) }
+          )
         end
       end
 

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -885,10 +885,10 @@ describe "Sensu::API::Process" do
       end
     end
 
-    it "renders empty list when no keys" do
+    it "renders empty hash when no keys" do
       api_test do
         api_request("/results/*/multi2") do |http,body|
-          expect(body).to eq([])
+          expect(body).to eq({})
           async_done
         end
       end


### PR DESCRIPTION
`GET /lock/<name>/<holder>/<ttl>` - give some coordination to standalone checks.

Standalone checks are isolated to sensu-client process and i don't [see an easy way / think it's good idea / feel there is any need] to expose sensu-server process state (is_leader) to them. Instead locking via simple get request could be simple and functional enough to coordinate these checks.

`GET /results/*/<check_name>` - allow fetching check results for all clients in sensu cluster.

To implement something like a cluster check at this point means either fetching list of all clients + N requests for a check result we need to observe, or expose redis connection details to sensu-client process and rely on sensu-implementation details of how check results are stored. I think it's useful/simple enough to just allow GET on results:*:<check_name>. Yes, that is still N+1 problem but at least it's within single API request.