### PR TITLE
Rescue MultiJson::ParseError to fix #836

### DIFF
--- a/lib/sensu/api/process.rb
+++ b/lib/sensu/api/process.rb
@@ -335,7 +335,14 @@ module Sensu
             clients.each_with_index do |client_name, index|
               settings.redis.get("client:#{client_name}") do |client_json|
                 unless client_json.nil?
-                  response << MultiJson.load(client_json)
+                  begin
+                    response << MultiJson.load(client_json)
+                  rescue MultiJson::ParseError => error
+                    settings.logger.error("failed to parse client registry payload", {
+                      :client_name => client_name,
+                      :error => error.to_s
+                    })
+                  end
                 else
                   settings.logger.error("client registry missing data for client", {
                     :client_name => client_name


### PR DESCRIPTION
As reported in #836, the Sensu API may exit if it encounters an issue parsing JSON responses from Redis. This PR simply catches the relevant exception and logs an error instead.