### PR TITLE
Fixes a broken test case for validation in Client API

### DIFF
--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -118,35 +118,53 @@ describe "Sensu::API::Process" do
     end
   end
 
-  it "can not create a client with an invalid post body" do
+  it "can not create a client with an invalid post body (invalid name)" do
     api_test do
       options = {
         :body => {
-          :name => "i-424242",
+          :name => "i-$$$$$$",
           :address => "8.8.8.8",
           :subscriptions => [
             "test"
           ]
         }
       }
-      invalid_name = options.dup
-      invalid_name[:body][:name] = "i-$$$$$$"
-      missing_address = options.dup
-      missing_address[:body].delete(:address)
-      invalid_subscriptions = options.dup
-      invalid_subscriptions[:body][:subscriptions] = "invalid"
-      api_request("/clients", :post, invalid_name) do |http, body|
+      api_request("/clients", :post, options) do |http, body|
         expect(http.response_header.status).to eq(400)
-        api_request("/clients", :post, missing_address) do |http, body|
-          expect(http.response_header.status).to eq(400)
-          api_request("/clients", :post, invalid_subscriptions) do |http, body|
-            expect(http.response_header.status).to eq(400)
-            api_request("/clients", :post) do |http, body|
-              expect(http.response_header.status).to eq(400)
-              async_done
-            end
-          end
-        end
+        async_done
+      end
+    end
+  end
+
+  it "can not create a client with an invalid post body (missing address)" do
+    api_test do
+      options = {
+        :body => {
+          :name => "i-424242",
+          :subscriptions => [
+            "test"
+          ]
+        }
+      }
+      api_request("/clients", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        async_done
+      end
+    end
+  end
+
+  it "can not create a client with an invalid post body (invalid subscriptions)" do
+    api_test do
+      options = {
+        :body => {
+          :name => "i-424242",
+          :address => "8.8.8.8",
+          :subscriptions => "invalid"
+        }
+      }
+      api_request("/clients", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        async_done
       end
     end
   end


### PR DESCRIPTION
This pull request fixes a broken test case for validation in Client API, which is named "can not create a client with an invalid post body".

The original test case intends to prepare three invalid sets of parameters (``invalid_name``, ``missing_address``, and ``invalid_subscriptions``), and asserts that Client API responds 400 for all of them.  However it actually tests only one set of parameters, because it uses Hash#dup to copy parameters, and thus an internal hash (``options[:body]``) is shared for them. As a result, the test case passes even if one of the validation rules is removed.

This pull request divides the test case to three individual cases so that the parameter set is not shared.
