### PR TITLE
Loosen EventMachine dependency, except on Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,3 +6,15 @@
 4. Commit your changes (`git commit -am 'Added some feature with tests'`)
 5. Push your feature branch (`git push origin my-new-feature`)
 6. Create a Pull Request
+
+### Testing
+
+Prequisite services
+
+- rabbitmq
+- redis
+
+```bash
+bundle
+RACK_ENV=development rake
+```

--- a/lib/sensu.rb
+++ b/lib/sensu.rb
@@ -1,3 +1,7 @@
+require 'rbconfig'
+if !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/) # windows
+  gem 'eventmachine', ENV.fetch("EVENTMACHINE_VERSION" { '= 1.0.3' } rescue abort("Windows requires eventmachine version 1.0.3\n\t#{$!.inspect}")
+end
 module Sensu
   # A monitoring framework that aims to be simple, malleable, & scalable.
 end

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json" if RUBY_VERSION < "1.9"
   s.add_dependency "multi_json", "1.11.2"
   s.add_dependency "uuidtools", "2.1.5"
-  s.add_dependency "eventmachine", "1.0.3"
+  s.add_dependency "eventmachine", ">= 1.0.3", "~> 1.0"
   s.add_dependency "sensu-em", "2.5.2"
   s.add_dependency "sensu-logger", "1.0.0"
   s.add_dependency "sensu-settings", "3.1.0"


### PR DESCRIPTION
Windows will fail on boot with a helpful message unless version 1.0.3 is
installed, though this can be overridden, if necessary, by setting
EVENTMACHINE_VERSION in the env.

This allows us to build on arm

Refs
- Closes #914
- #905
- #896
- #897