### PR TITLE
Fixed metric check output truncation when output is empty

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -210,7 +210,7 @@ module Sensu
         case check[:type]
         when "metric"
           output_lines = check[:output].split("\n")
-          output = output_lines.first
+          output = output_lines.first || check[:output]
           if output_lines.size > 1 || output.length > 255
             output = output[0..255] + "\n..."
           end

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -207,12 +207,24 @@ describe "Sensu::Server::Process" do
       redis.flushdb do
         timer(1) do
           check = check_template
+          check[:output] = "foo"
+          truncated = @server.truncate_check_output(check)
+          expect(truncated[:output]).to eq("foo")
+          check[:output] = ""
+          truncated = @server.truncate_check_output(check)
+          expect(truncated[:output]).to eq("")
           check[:output] = "foo\nbar\nbaz"
           truncated = @server.truncate_check_output(check)
           expect(truncated[:output]).to eq("foo\nbar\nbaz")
           check[:type] = "metric"
           truncated = @server.truncate_check_output(check)
           expect(truncated[:output]).to eq("foo\n...")
+          check[:output] = "foo"
+          truncated = @server.truncate_check_output(check)
+          expect(truncated[:output]).to eq("foo")
+          check[:output] = ""
+          truncated = @server.truncate_check_output(check)
+          expect(truncated[:output]).to eq("")
           check[:output] = rand(36**256).to_s(36)
           truncated = @server.truncate_check_output(check)
           expect(truncated[:output]).to eq(check[:output][0..255] + "\n...")


### PR DESCRIPTION
Turns out `split("\n")` on an empty string produces an empty array.
```
[1] pry(main)> check = {:output => "foo"}                                                                                                            
=> {:output=>"foo"}
[2] pry(main)> output_lines = check[:output].split("\n")                                                                                             
=> ["foo"]
[3] pry(main)> check = {:output => ""}                                                                                                               
=> {:output=>""}
[4] pry(main)> output_lines = check[:output].split("\n")                                                                                             
=> []
```