### PR TITLE
Fixes misuse of regexp metacharacters "^" and "$"

### DIFF
--- a/lib/sensu/api/process.rb
+++ b/lib/sensu/api/process.rb
@@ -190,7 +190,7 @@ module Sensu
         end
 
         def integer_parameter(parameter)
-          parameter =~ /^[0-9]+$/ ? parameter.to_i : nil
+          parameter =~ /\A[0-9]+\z/ ? parameter.to_i : nil
         end
 
         def pagination(items)

--- a/lib/sensu/api/process.rb
+++ b/lib/sensu/api/process.rb
@@ -311,7 +311,7 @@ module Sensu
 
       apost "/clients/?" do
         rules = {
-          :name => {:type => String, :nil_ok => false, :regex => /^[\w\.-]+$/},
+          :name => {:type => String, :nil_ok => false, :regex => /\A[\w\.-]+\z/},
           :address => {:type => String, :nil_ok => false},
           :subscriptions => {:type => Array, :nil_ok => false}
         }

--- a/lib/sensu/client/socket.rb
+++ b/lib/sensu/client/socket.rb
@@ -116,10 +116,10 @@ module Sensu
       #
       # @param [Hash] check result to validate.
       def validate_check_result(check)
-        unless check[:name] =~ /^[\w\.-]+$/
+        unless check[:name] =~ /\A[\w\.-]+\z/
           raise DataError, "check name must be a string and cannot contain spaces or special characters"
         end
-        unless check[:source].nil? || check[:source] =~ /^[\w\.-]+$/
+        unless check[:source].nil? || check[:source] =~ /\A[\w\.-]+\z/
           raise DataError, "check source must be a string and cannot contain spaces or special characters"
         end
         unless check[:output].is_a?(String)

--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -179,7 +179,7 @@ module Sensu
       # @return [TrueClass, FalseClass]
       def eval_attribute_value(raw_eval_string, value)
         begin
-          eval_string = raw_eval_string.gsub(/^eval:(\s+)?/, "")
+          eval_string = raw_eval_string.gsub(/\Aeval:(\s+)?/, "")
           !!Sandbox.eval(eval_string, value)
         rescue => error
           @logger.error("filter attribute eval error", {

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -136,6 +136,24 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can not create a client with an invalid post body (multiline name)" do
+    api_test do
+      options = {
+        :body => {
+          :name => "i-424242\ni-424242",
+          :address => "8.8.8.8",
+          :subscriptions => [
+            "test"
+          ]
+        }
+      }
+      api_request("/clients", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        async_done
+      end
+    end
+  end
+
   it "can not create a client with an invalid post body (missing address)" do
     api_test do
       options = {

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -37,6 +37,13 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can handle integer parameters" do
+    api = Sensu::API::Process.new!
+    expect(api.integer_parameter("42")).to eq(42)
+    expect(api.integer_parameter("abc")).to eq(nil)
+    expect(api.integer_parameter("42\nabc")).to eq(nil)
+  end
+
   it "can provide basic version and health information" do
     api_test do
       api_request("/info") do |http, body|

--- a/spec/client/socket_spec.rb
+++ b/spec/client/socket_spec.rb
@@ -47,8 +47,18 @@ describe Sensu::Client::Socket do
       "check name must be a string and cannot contain spaces or special characters"
 
     it_should_behave_like "a validator",
+      "must contain a single-line check name",
+      {:name => "check\nname"},
+      "check name must be a string and cannot contain spaces or special characters"
+
+    it_should_behave_like "a validator",
       "must contain an acceptable check source",
       {:source => "check source"},
+      "check source must be a string and cannot contain spaces or special characters"
+
+    it_should_behave_like "a validator",
+      "must contain a single-line check source",
+      {:source => "check\nsource"},
       "check source must be a string and cannot contain spaces or special characters"
 
     it_should_behave_like "a validator",

--- a/spec/server/filter_spec.rb
+++ b/spec/server/filter_spec.rb
@@ -144,6 +144,9 @@ describe "Sensu::Server::Filter" do
     attributes[:occurrences] = "eval: value == 1 || value % 60 == 0"
     @event[:occurrences] = 1
     expect(@server.filter_attributes_match?(attributes, @event)).to be(true)
+    attributes[:occurrences] = "eval: value == '\neval:'.size || value % 60 == 0"
+    @event[:occurrences] = "\neval:".size
+    expect(@server.filter_attributes_match?(attributes, @event)).to be(true)
     @event[:occurrences] = 2
     expect(@server.filter_attributes_match?(attributes, @event)).to be(false)
     @event[:occurrences] = 120


### PR DESCRIPTION
This pull request fixes misuse of regexp metacharacters "^" (start of line) and "$" (end of line) all over the source tree. Those metacharacters are wrongly used where "\A" (start of string) and "\z" (end of string) should be used instead.

Consequently, this pull request fixes bugs as follows.

- Client API has been accepting multiline client names
- API has been accepting multiline input for integral parameters
- Client Socket has been accepting multiline check names and source names
- "occurrence" scripts for filters has not been evaluated correctly if they contain "\neval:"
