### PR TITLE
Fix randomly occurring false negative test results for truncation of check output

### DIFF
--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -225,7 +225,7 @@ describe "Sensu::Server::Process" do
           check[:output] = ""
           truncated = @server.truncate_check_output(check)
           expect(truncated[:output]).to eq("")
-          check[:output] = rand(36**256).to_s(36)
+          check[:output] = rand(36**256).to_s(36).rjust(256, '0')
           truncated = @server.truncate_check_output(check)
           expect(truncated[:output]).to eq(check[:output][0..255] + "\n...")
           client = client_template


### PR DESCRIPTION
This pull request fixes a test for truncation of check output which causes false negative randomly.

The test tries to generate a string of 256 characters and asserts that the string is truncated to 255 characters. But actually it sometimes (once in 16 times exactly) generates less than 256 characters and causes a false negative test result. For example:

https://travis-ci.org/sensu/sensu/jobs/79523141

This pull request justifies the string to 256 characters.

I hope it will reduce big red cross marks on the PR list and let us be happier ;)