### PR TITLE
Reduce failures of the test case for check result consumption

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -53,9 +53,9 @@ module Helpers
     end
   end
 
-  def async_wrapper(&callback)
+  def async_wrapper(timeout_secs = 15, &callback)
     EM::run do
-      timer(15) do
+      timer(timeout_secs) do
         raise "test timed out"
       end
       callback.call

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -159,35 +159,37 @@ describe "Sensu::Server::Process" do
           redis.set("client:i-424242", MultiJson.dump(client)) do
             result = result_template
             transport.publish(:direct, "results", MultiJson.dump(result))
-            transport.publish(:direct, "results", MultiJson.dump(result))
-            timer(2) do
-              redis.sismember("result:i-424242", "test") do |is_member|
-                expect(is_member).to be(true)
-                redis.get("result:i-424242:test") do |result_json|
-                  result = MultiJson.load(result_json)
-                  expect(result[:output]).to eq("WARNING")
-                  timer(7) do
-                    redis.hget("events:i-424242", "test") do |event_json|
-                      event = MultiJson.load(event_json)
-                      expect(event[:id]).to be_kind_of(String)
-                      expect(event[:check][:status]).to eq(1)
-                      expect(event[:occurrences]).to eq(2)
-                      expect(event[:action]).to eq("create")
-                      expect(event[:timestamp]).to be_within(10).of(epoch)
-                      read_event_file = Proc.new do
-                        begin
-                          event_file = IO.read("/tmp/sensu_event_bridge.json")
-                          MultiJson.load(event_file)
-                        rescue
-                          retry
+            timer(1) do
+              transport.publish(:direct, "results", MultiJson.dump(result))
+              timer(2) do
+                redis.sismember("result:i-424242", "test") do |is_member|
+                  expect(is_member).to be(true)
+                  redis.get("result:i-424242:test") do |result_json|
+                    result = MultiJson.load(result_json)
+                    expect(result[:output]).to eq("WARNING")
+                    timer(7) do
+                      redis.hget("events:i-424242", "test") do |event_json|
+                        event = MultiJson.load(event_json)
+                        expect(event[:id]).to be_kind_of(String)
+                        expect(event[:check][:status]).to eq(1)
+                        expect(event[:occurrences]).to eq(2)
+                        expect(event[:action]).to eq("create")
+                        expect(event[:timestamp]).to be_within(10).of(epoch)
+                        read_event_file = Proc.new do
+                          begin
+                            event_file = IO.read("/tmp/sensu_event_bridge.json")
+                            MultiJson.load(event_file)
+                          rescue
+                            retry
+                          end
                         end
+                        compare_event_file = Proc.new do |event_file|
+                          expect(event_file[:check]).to eq(event[:check])
+                          expect(event_file[:client]).to eq(event[:client])
+                          async_done
+                        end
+                        EM.defer(read_event_file, compare_event_file)
                       end
-                      compare_event_file = Proc.new do |event_file|
-                        expect(event_file[:check]).to eq(event[:check])
-                        expect(event_file[:client]).to eq(event[:client])
-                        async_done
-                      end
-                      EM.defer(read_event_file, compare_event_file)
                     end
                   end
                 end

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -149,7 +149,7 @@ describe "Sensu::Server::Process" do
   end
 
   it "can consume results" do
-    async_wrapper do
+    async_wrapper(30) do
       @server.setup_transport
       @server.setup_redis
       @server.setup_results


### PR DESCRIPTION
The test case "can consume results" fails often because of race condition or timeout. This pull request reduces the chance of them.

## Failure mode 1: timeout

The test may fail because of timeout. Examples:

- https://travis-ci.org/sensu/sensu/jobs/81634354
- https://travis-ci.org/sensu/sensu/jobs/79522099

This pull request increases the timeout threshold.

## Failure mode 2: unexpected occurrences count

``occurrences`` attribute of the event may differ from the expectation. Examples:

- https://travis-ci.org/sensu/sensu/jobs/79522897
- https://travis-ci.org/sensu/sensu/jobs/78767727

Probably the failures occur because two check results published by the test case are processed concurrently and cause race condition. It cannot easily be avoided because Redis lacks an atomic read-modify-write feature.

This pull request add a wait between the publishments of check results. It increases the chance that the check results are processed serially.

## Failure mode 3: mismatch between Redis and the output of a bridge

The output by ``Sensu::Extension::LatestEventFile`` may differ from the content in Redis. Example:

- https://travis-ci.org/sensu/sensu/jobs/68232751

Probably this situation occurs when EventMachine processes a task for the latter check result first. I cannot decide if this situation is worth to be fixed.

This pull request only reduce the chance of the situation, in the same way as the failure mode 2.
