### PR TITLE
Send the extension name for checks

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -483,12 +483,12 @@ module Sensu
       end
 
       # Publish a check request to the transport. A check request is
-      # composted of a check `:name`, an `:issued` timestamp, and a
-      # check `:command` if available. The check request is published
-      # to a transport pipe, for each of the check `:subscribers` in
-      # its definition, eg. "webserver". JSON serialization is used
-      # when publishing the check request payload to the transport
-      # pipes. Transport errors are logged.
+      # composed of a check `:name`, an `:issued` timestamp, a check
+      # `:command` if available, and a check `:extension if available.
+      # The check request is published to a transport pipe, for each
+      # of the check `:subscribers` in its definition, eg. "webserver".
+      # JSON serialization is used when publishing the check request
+      # payload to the transport pipes. Transport errors are logged.
       #
       # @param check [Hash] definition.
       def publish_check_request(check)
@@ -498,6 +498,12 @@ module Sensu
         }
         payload[:command] = check[:command] if check.has_key?(:command)
         payload[:source] = check[:source] if check.has_key?(:source)
+        if check.has_key?(:extension)
+          if check.has_key?(:command) 
+            @logger.warn("check has both command and extension options, command overrides extension", :check => check)
+          end  
+          payload[:extension] = check[:extension]
+        end
         @logger.info("publishing check request", {
           :payload => payload,
           :subscribers => check[:subscribers]

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -113,6 +113,17 @@ module Helpers
     }
   end
 
+  def extension_check_template
+    {
+      :name => "test",
+      :issued => epoch,
+      :extension => "test-extension",
+      :output => "WARNING",
+      :status => 1,
+      :executed => 1363224805
+    }
+  end
+
   def result_template(check_result = nil)
     {
       :client => "i-424242",


### PR DESCRIPTION
Fixes issue [#1078](https://github.com/sensu/sensu/issues/1078)

Sends the extension name if it exists in a check definition. Will output a warning message if both check :command and :extension keys exist. Unsure what behaviour would be best for that scenario, a command and extension shouldn't ever both be set so perhaps this would be better if it logged an error and didn't publish such checks.

From what I can see looking through the lib/sensu/client/process.rb process_check_request method, the extension name should be different from the check name, as the default behaviour is running the check as an extension check with the extension name set to the check name.