### PR TITLE
First pass at a CLI tool for installing Sensu plugins

### DIFF
--- a/exe/sensu-install
+++ b/exe/sensu-install
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+
+require "optparse"
+
+module Sensu
+  class Install
+    class << self
+      def cli_options(arguments=ARGV)
+        options = {
+          :plugins => [],
+          :verbose => false
+        }
+        optparse = OptionParser.new do |opts|
+          opts.on("-h", "--help", "Display this message") do
+            puts opts
+            exit
+          end
+          opts.on("-v", "--verbose", "Enable verbose logging") do
+            options[:verbose] = true
+          end
+          opts.on("-p", "--plugin PLUGIN", "Install a Sensu PLUGIN") do |plugin|
+            options[:plugins] << plugin
+          end
+          opts.on("-P", "--plugins PLUGIN[,PLUGIN]", "PLUGIN or comma-delimited list of Sensu plugins to install") do |plugins|
+            options[:plugins].concat(plugins.split(","))
+          end
+          opts.on("-s", "--source SOURCE", "Install Sensu plugins and/or extensions from a custom SOURCE") do |source|
+            options[:source] = source
+          end
+        end
+        optparse.parse!(arguments)
+        options
+      end
+
+      def log(message)
+        puts "[SENSU-INSTALL] #{message}"
+      end
+
+      def install_plugins(plugins, options={})
+        log "installing Sensu plugins ..."
+        log "provided Sensu plugins: #{plugins}" if options[:verbose]
+        gems = plugins.map do |plugin|
+          if plugin.start_with?("sensu-plugins-")
+            plugin
+          else
+            "sensu-plugins-#{plugin}"
+          end
+        end
+        log "Sensu plugin gems to be installed: #{gems}" if options[:verbose]
+        gem_options = "--no-ri --no-rdoc"
+        gem_options << " --verbose" if options[:verbose]
+        gem_options << " --source #{options[:source]}" if options[:source]
+        gems.each do |gem|
+          log "installing Sensu plugin gem #{gem}"
+          gem_command = "gem install #{gem} #{gem_options}"
+          log gem_command if options[:verbose]
+          unless system(gem_command)
+            log "failed to install Sensu plugin gem #{gem}"
+            log "you can run the sensu-install command again with --verbose for more info" unless options[:verbose]
+            log "please take note of any failure messages above"
+            log "make sure you have build tools installed (e.g. gcc)"
+            log "trying to determine Sensu plugin homepage for #{gem} ..."
+            clean_gem = gem.split(":").first
+            system("gem specification #{clean_gem} -r | grep homepage")
+            exit 2
+          end
+        end
+      end
+
+      def run
+        options = cli_options
+        unless options[:plugins].empty?
+          install_plugins(options[:plugins], options)
+        end
+      end
+    end
+  end
+end
+
+Sensu::Install.run

--- a/exe/sensu-install
+++ b/exe/sensu-install
@@ -24,7 +24,7 @@ module Sensu
           opts.on("-P", "--plugins PLUGIN[,PLUGIN]", "PLUGIN or comma-delimited list of Sensu plugins to install") do |plugins|
             options[:plugins].concat(plugins.split(","))
           end
-          opts.on("-s", "--source SOURCE", "Install Sensu plugins and/or extensions from a custom SOURCE") do |source|
+          opts.on("-s", "--source SOURCE", "Install Sensu plugins from a custom SOURCE") do |source|
             options[:source] = source
           end
         end
@@ -71,6 +71,8 @@ module Sensu
         options = cli_options
         unless options[:plugins].empty?
           install_plugins(options[:plugins], options)
+        else
+          log "nothing to do"
         end
       end
     end

--- a/exe/sensu-install
+++ b/exe/sensu-install
@@ -7,8 +7,8 @@ module Sensu
     class << self
       def cli_options(arguments=ARGV)
         options = {
-          :plugins => [],
-          :verbose => false
+          :verbose => false,
+          :plugins => []
         }
         optparse = OptionParser.new do |opts|
           opts.on("-h", "--help", "Display this message") do

--- a/exe/sensu-install
+++ b/exe/sensu-install
@@ -51,11 +51,11 @@ module Sensu
         gem_options << " --verbose" if options[:verbose]
         gem_options << " --source #{options[:source]}" if options[:source]
         gems.each do |gem|
-          log "installing Sensu plugin gem #{gem}"
+          log "installing Sensu plugin gem: #{gem}"
           gem_command = "gem install #{gem} #{gem_options}"
           log gem_command if options[:verbose]
           unless system(gem_command)
-            log "failed to install Sensu plugin gem #{gem}"
+            log "failed to install Sensu plugin gem: #{gem}"
             log "you can run the sensu-install command again with --verbose for more info" unless options[:verbose]
             log "please take note of any failure messages above"
             log "make sure you have build tools installed (e.g. gcc)"
@@ -65,6 +65,7 @@ module Sensu
             exit 2
           end
         end
+        log "successfully install Sensu plugins: #{plugins}"
       end
 
       def run


### PR DESCRIPTION
Example output:

```
portertech@d2o:~/projects/sensu/sensu (feature/sensu-install)$ ./exe/sensu-install -h
Usage: sensu-install [options]
    -h, --help                       Display this message
    -v, --verbose                    Enable verbose logging
    -p, --plugin PLUGIN              Install a Sensu PLUGIN
    -P, --plugins PLUGIN[,PLUGIN]    PLUGIN or comma-delimited list of Sensu plugins to install
    -s, --source SOURCE              Install Sensu plugins from a custom SOURCE
```

```
portertech@d2o:~/projects/sensu/sensu (feature/sensu-install)$ ./exe/sensu-install -v -P elasticsearch:0.1.2,sensu-plugins-serverspec 
[SENSU-INSTALL] installing Sensu plugins ...
[SENSU-INSTALL] provided Sensu plugins: ["elasticsearch:0.1.2", "sensu-plugins-serverspec"]
[SENSU-INSTALL] Sensu plugin gems to be installed: ["sensu-plugins-elasticsearch:0.1.2", "sensu-plugins-serverspec"]
[SENSU-INSTALL] installing Sensu plugin gem sensu-plugins-elasticsearch:0.1.2
[SENSU-INSTALL] gem install sensu-plugins-elasticsearch:0.1.2 --no-ri --no-rdoc --verbose
GET https://api.rubygems.org/specs.4.8.gz
302 Moved Temporarily
GET https://rubygems.global.ssl.fastly.net/specs.4.8.gz
200 OK
...
/home/portertech/.gem/ruby/2.1.2/bin/metrics-es-node.rb
/home/portertech/.gem/ruby/2.1.2/bin/metrics-es-node-graphite.rb
/home/portertech/.gem/ruby/2.1.2/bin/metrics-es-cluster.rb
/home/portertech/.gem/ruby/2.1.2/bin/check-es-node-status.rb
/home/portertech/.gem/ruby/2.1.2/bin/check-es-heap.rb
/home/portertech/.gem/ruby/2.1.2/bin/check-es-file-descriptors.rb
/home/portertech/.gem/ruby/2.1.2/bin/check-es-cluster-status.rb
You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu
Successfully installed sensu-plugins-elasticsearch-0.1.2
2 gems installed
[SENSU-INSTALL] installing Sensu plugin gem sensu-plugins-serverspec
[SENSU-INSTALL] gem install sensu-plugins-serverspec --no-ri --no-rdoc --verbose
GET https://api.rubygems.org/latest_specs.4.8.gz
302 Moved Temporarily
GET https://rubygems.global.ssl.fastly.net/latest_specs.4.8.gz
304 Not Modified
HEAD https://api.rubygems.org/api/v1/dependencies
200 OK
...
/home/portertech/.gem/ruby/2.1.2/bin/check-serverspec.rb
You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu
Successfully installed sensu-plugins-serverspec-0.0.2
1 gem installed
```

We will need to create a bin stub in https://github.com/sensu/sensu-build that sources `/etc/default/sensu` for `EMBEDDED_RUBY`.