### PR TITLE
API POST /results for check result input

### DIFF
--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -877,6 +877,56 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can publish a check result" do
+    api_test do
+      options = {
+        :body => {
+          :name => "rspec",
+          :output => "WARNING",
+          :status => 1
+        }
+      }
+      api_request("/results", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(202)
+        expect(body).to include(:issued)
+        async_done
+      end
+    end
+  end
+
+  it "can not publish a check result with an invalid post body" do
+    api_test do
+      options = {
+        :body => {
+          :name => "rspec",
+          :output => "WARNING",
+          :status => 1,
+          :source => "$invalid$"
+        }
+      }
+      api_request("/results", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        expect(body).to be_empty
+        async_done
+      end
+    end
+  end
+
+  it "can not publish a check result when missing data" do
+    api_test do
+      options = {
+        :body => {
+          :name => "missing_output"
+        }
+      }
+      api_request("/results", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        expect(body).to be_empty
+        async_done
+      end
+    end
+  end
+
   it "can provide current results" do
     api_test do
       api_request("/results") do |http, body|


### PR DESCRIPTION
This PR adds the POST /results API endpoint. The new endpoint accepts JSON check results, publishing them with the client name "sensu-api". JIT clients (https://sensuapp.org/docs/latest/clients#jit-clients) enable this feature. This is essentially an HTTP version of the Sensu client socket, supporting basic authentication.

```
$ curl -iXPOST -d '{"name": "example", "output": "nice"}' http://foo:bar@localhost:4567/results
HTTP/1.1 202 Accepted
Content-Type: application/json
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization
Content-Length: 21
Connection: keep-alive
Server: thin

{"issued":1447350519}
```