### PR TITLE
PR #1082 cleanup, config validation does not allow both check command and extension

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -498,12 +498,7 @@ module Sensu
         }
         payload[:command] = check[:command] if check.has_key?(:command)
         payload[:source] = check[:source] if check.has_key?(:source)
-        if check.has_key?(:extension)
-          if check.has_key?(:command) 
-            @logger.warn("check has both command and extension options, command overrides extension", :check => check)
-          end  
-          payload[:extension] = check[:extension]
-        end
+        payload[:extension] = check[:extension] if check.has_key?(:extension)
         @logger.info("publishing check request", {
           :payload => payload,
           :subscribers => check[:subscribers]

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -113,17 +113,6 @@ module Helpers
     }
   end
 
-  def extension_check_template
-    {
-      :name => "test",
-      :issued => epoch,
-      :extension => "test-extension",
-      :output => "WARNING",
-      :status => 1,
-      :executed => 1363224805
-    }
-  end
-
   def result_template(check_result = nil)
     {
       :client => "i-424242",

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -327,33 +327,18 @@ describe "Sensu::Server::Process" do
         check_request = MultiJson.load(payload)
         expect(check_request[:name]).to eq("test")
         expect(check_request[:source]).to eq("switch-x")
-        expect(check_request[:extension]).to eq("test-extension")
+        expect(check_request[:extension]).to eq("rspec")
         expect(check_request[:issued]).to be_within(10).of(epoch)
+        expect(check_request).not_to include(:command)
         async_done
       end
       timer(0.5) do
         @server.setup_transport
-        check = extension_check_template
+        check = check_template
+        check.delete(:command)
+        check[:extension] = "rspec"
         check[:subscribers] = ["test"]
         check[:source] = "switch-x"
-        @server.publish_check_request(check)
-      end
-    end
-  end
-
-  it "can publish extension check requests to round-robin subscriptions" do
-    async_wrapper do
-      transport.subscribe(:direct, "roundrobin:test") do |_, payload|
-        check_request = MultiJson.load(payload)
-        expect(check_request[:name]).to eq("test")
-        expect(check_request[:extension]).to eq("test-extension")
-        expect(check_request[:issued]).to be_within(10).of(epoch)
-        async_done
-      end
-      timer(0.5) do
-        @server.setup_transport
-        check = extension_check_template
-        check[:subscribers] = ["roundrobin:test"]
         @server.publish_check_request(check)
       end
     end


### PR DESCRIPTION
Removed command + extension warning log event as this situation cannot occur due to configuration validation (https://github.com/sensu/sensu-settings/blob/master/lib/sensu/settings/validators/check.rb#L25-L26). Minor test updates.