### PR TITLE
add support for api extensions

### DIFF
--- a/lib/sensu/api/process.rb
+++ b/lib/sensu/api/process.rb
@@ -49,6 +49,7 @@ module Sensu
             "Credentials" => "true",
             "Headers" => "Origin, X-Requested-With, Content-Type, Accept, Authorization"
           }
+          load_api_extensions
           on_reactor_run
           self
         end
@@ -92,6 +93,15 @@ module Sensu
         def test(options={})
           bootstrap(options)
           start
+        end
+
+        def load_api_extensions
+          if @settings[:api_extensions]
+            @settings[:api_extensions].each_pair do |name, filename|
+              settings.logger.info("loading api extension #{name} from #{filename}")
+              require filename
+            end
+          end
         end
       end
 


### PR DESCRIPTION
I would like to be able to add my own API endpoints/calls to sensu-api. Here I am proposing a simple mechanism to make it happen.

In a nutshell, make settings[:api_extensions] a hash with human readable name of extension as key and absolute file name as value.

```
api_extensions:
  my_extension1: /path/to/filename1.rb
  my_extension2: /path/to/filename2.rb
```

In filename*.rb it's as simple as:

```
Sensu::API::Process.class_eval do

  aget ...

end
```

Thoughts?
