### PR TITLE
Create a dup of the filter list before mutating

### DIFF
--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -258,7 +258,7 @@ module Sensu
       # @param callback [Proc]
       def event_filtered?(handler, event, &callback)
         if handler.has_key?(:filters) || handler.has_key?(:filter)
-          filter_list = handler.has_key?(:filters)? handler[:filters].clone : [handler[:filter]]
+          filter_list = Array(handler[:filters] || handler[:filter]).dup
           filter = Proc.new do |filter_list|
             filter_name = filter_list.shift
             if filter_name.nil?


### PR DESCRIPTION
- Array() does not create a new object if the parameter is
                already an array