### PR TITLE
Correct sensu-install typo, install -> installed

### DIFF
--- a/exe/sensu-install
+++ b/exe/sensu-install
@@ -65,7 +65,7 @@ module Sensu
             exit 2
           end
         end
-        log "successfully install Sensu plugins: #{plugins}"
+        log "successfully installed Sensu plugins: #{plugins}"
       end
 
       def run


### PR DESCRIPTION
As reported by @chrisroberts 