### PR TITLE
Make the client socket accept non-ASCII characters

### DIFF
--- a/lib/sensu/client/socket.rb
+++ b/lib/sensu/client/socket.rb
@@ -186,6 +186,7 @@ module Sensu
       #
       # @param [String] data to be processed.
       def process_data(data)
+        data = data.force_encoding('utf-8')
         if data.strip == "ping"
           @logger.debug("socket received ping")
           respond("pong")
@@ -193,6 +194,10 @@ module Sensu
           @logger.debug("socket received data", {
             :data => data
           })
+          if not data.valid_encoding?
+            @logger.warn("data from socket is not valid UTF-8 sequence, but processes it anyway",
+                         :data => data.inspect)
+          end
           begin
             parse_check_result(data)
           rescue => error

--- a/lib/sensu/client/socket.rb
+++ b/lib/sensu/client/socket.rb
@@ -195,7 +195,7 @@ module Sensu
           })
           if not valid_utf8?(data)
             @logger.warn("data from socket is not valid UTF-8 sequence, but processes it anyway",
-                         :data => data.inspect)
+                         :data => data)
           end
           begin
             parse_check_result(data)

--- a/lib/sensu/client/socket.rb
+++ b/lib/sensu/client/socket.rb
@@ -186,10 +186,7 @@ module Sensu
       #
       # @param [String] data to be processed.
       def process_data(data)
-        if data.bytes.find { |char| char > 0x80 }
-          @logger.warn("socket received non-ascii characters")
-          respond("invalid")
-        elsif data.strip == "ping"
+        if data.strip == "ping"
           @logger.debug("socket received ping")
           respond("pong")
         else

--- a/spec/client/socket_spec.rb
+++ b/spec/client/socket_spec.rb
@@ -167,7 +167,7 @@ describe Sensu::Client::Socket do
         with("socket received data", :data => data)
       expect(logger).to receive(:warn).
         with("data from socket is not valid UTF-8 sequence, but processes it anyway",
-             :data => data.force_encoding('BINARY').inspect)
+             :data => data)
       expect(subject).to receive(:parse_check_result).with(data)
       subject.process_data(data)
     end

--- a/spec/client/socket_spec.rb
+++ b/spec/client/socket_spec.rb
@@ -167,7 +167,7 @@ describe Sensu::Client::Socket do
         with("socket received data", :data => data)
       expect(logger).to receive(:warn).
         with("data from socket is not valid UTF-8 sequence, but processes it anyway",
-             :data => data.force_encoding('utf-8').inspect)
+             :data => data.force_encoding('BINARY').inspect)
       expect(subject).to receive(:parse_check_result).with(data)
       subject.process_data(data)
     end

--- a/spec/client/socket_spec.rb
+++ b/spec/client/socket_spec.rb
@@ -159,6 +159,18 @@ describe Sensu::Client::Socket do
       expect(subject).to receive(:parse_check_result).with(data)
       subject.process_data(data)
     end
+
+    it "warn-logs encoding error" do
+      # contains invalid sequence as UTF-8
+      data = "{\"data\":\"\xc2\x7f\"}"
+      expect(logger).to receive(:debug).
+        with("socket received data", :data => data)
+      expect(logger).to receive(:warn).
+        with("data from socket is not valid UTF-8 sequence, but processes it anyway",
+             :data => data.force_encoding('utf-8').inspect)
+      expect(subject).to receive(:parse_check_result).with(data)
+      subject.process_data(data)
+    end
   end
 
   describe "#receive_data" do


### PR DESCRIPTION
JSON data encoded as UTF-8 may contain non-ASCII bytes (>=0x80), but currently the client socket rejects such data. This pull-request makes the client socket accept non-ASCII characters and parse them as UTF-8.

Reference:

- [Character Encoding in JSON](https://tools.ietf.org/html/rfc7159#section-8.1)

Indeed non-ASCII characters can be encoded using `\uXXXX` notation, but it imposes extra effort on the client side. Particularly, ruby code can be messy because popular JSON libraries do not support `\uXXXX` notation in dump methods. Example:

- [out_sensu.rb in fluent-plugin-sensu](https://github.com/miyakawataku/fluent-plugin-sensu/blob/v1.0.1/lib/fluent/plugin/out_sensu.rb#L200)
