### PR TITLE
Add simple client validation

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -74,10 +74,11 @@ module Sensu
       end
 
       # Publish a check result to the transport for processing. A
-      # check result is composed of a client (name) and a check
-      # definition, containing check `:output` and `:status`. JSON
-      # serialization is used when publishing the check result payload
-      # to the transport pipe. Transport errors are logged.
+      # check result is composed of a client (name), the unique
+      # client_key, and a check definition, containing check
+      # `:output` and `:status`. JSON serialization is used when
+      # publishing the check result payload to the transport pipe.
+      # Transport errors are logged.
       #
       # @param check [Hash]
       def publish_check_result(check)
@@ -85,6 +86,9 @@ module Sensu
           :client => @settings[:client][:name],
           :check => check
         }
+        if @settings[:client].has_key?(:client_key)
+          payload.merge(:client_key => @settings[:client][:client_key])
+        end
         @logger.info("publishing check result", :payload => payload)
         @transport.publish(:direct, "results", MultiJson.dump(payload)) do |info|
           if info[:error]

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -84,11 +84,9 @@ module Sensu
       def publish_check_result(check)
         payload = {
           :client => @settings[:client][:name],
+          :client_key => @settings[:client][:client_key],
           :check => check
         }
-        if @settings[:client].has_key?(:client_key)
-          payload.merge!(:client_key => @settings[:client][:client_key])
-        end
         @logger.info("publishing check result", :payload => payload)
         @transport.publish(:direct, "results", MultiJson.dump(payload)) do |info|
           if info[:error]

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -87,7 +87,7 @@ module Sensu
           :check => check
         }
         if @settings[:client].has_key?(:client_key)
-          payload.merge(:client_key => @settings[:client][:client_key])
+          payload.merge!(:client_key => @settings[:client][:client_key])
         end
         @logger.info("publishing check result", :payload => payload)
         @transport.publish(:direct, "results", MultiJson.dump(payload)) do |info|

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -55,7 +55,7 @@ module Sensu
             registered_client = MultiJson.load(registered_client_json)
             if registered_client.has_key?(:client_key)
               if client.has_key?(:client_key) && registered_client[:client_key] == client[:client_key]
-                @logger.debug("valid client", :client => client)
+                @logger.debug("client is valid", :client => client)
                 callback.call(true)
               else
                 @logger.error("invalid client, client keys do not match or missing", :client => client)
@@ -109,7 +109,7 @@ module Sensu
                   @transport.ack(message_info)
                 end
               else
-                @logger.error("client submitted keepalive that failed validation", :client => client)
+                @logger.error("client submitted keepalive that failed validation - rejecting", :client => client)
                 @transport.ack(message_info)
               end
             end
@@ -498,7 +498,7 @@ module Sensu
               if valid_client
                 process_check_result(result)
               else
-                @logger.error("client submitted result that failed validation", :result => result)
+                @logger.error("client submitted result that failed validation - rejecting", :result => result)
               end
             end
           rescue MultiJson::ParseError => error

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -635,7 +635,7 @@ module Sensu
           :check => check
         }
         unless client_key.nil?
-          payload.merge(:client_key => client_key)
+          payload.merge!(:client_key => client_key)
         end
         @logger.debug("publishing check result", :payload => payload)
         @transport.publish(:direct, "results", MultiJson.dump(payload)) do |info|

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -58,14 +58,15 @@ module Sensu
                 @logger.debug("client is valid", :client => client)
                 callback.call(true)
               else
-                @logger.error("invalid client, client keys do not match or missing", :client => client)
+                @logger.error("invalid client - client keys do not match or missing", :client => client)
                 callback.call(false)
               end
             else
               @logger.debug("registered client has no client_key set - validating", :client => client)
+              callback.call(true)
             end
           else
-            @logger.debug("no previous entry for client to validate", :client => client)
+            @logger.debug("client not in registry - validating", :client => client)
             callback.call(true)
           end
         end

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -381,7 +381,7 @@ describe "Sensu::Server::Process" do
         @server.setup_transport
         client = client_template
         check = result_template[:check]
-        @server.publish_check_result(client[:name], check)
+        @server.publish_check_result(client[:name], client[:client_key], check)
       end
     end
   end


### PR DESCRIPTION
Clients can now optionally set a `client_key` in their configuration,
which will be passed along in keepalives and check results. If set,
validation is as follows:

- When new clients are registered, the `client_key` is stored along with
  all the other attributes in Redis.
- When keepalives or check results are received, the respective
  functions will call `validate_client` to ensure the messages are
  authentic.
- `validate_client` will check the registry for the client and fetch the
  `client_key`.
  - If a previously registered client had a `client_key`, and the
    incoming message did not, it will fail validation.
  - If the keys do not match, it will fail validation.
  - If the registered client did not have a `client_key`, it will pass
    validation.
  - If there was no previously registered client, it will pass
    validation.

This is a simplistic form of validation and should not be considered
100% secure. This merely adds some basic security to incoming messages.