### PR TITLE
Client registration events

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -37,6 +37,15 @@ module Sensu
         @handling_event_count = 0
       end
 
+      # Create a registration check definition for a client. Client
+      # definitions may contain `:registration` configuration,
+      # containing custom attributes and handler information. By
+      # default, the registration check definition sets the `:handler`
+      # to `registration`. If the client provides its own
+      # `:registration` configuration, it's deep merged with the
+      # defaults. The check `:name`, `:output`, `:status`, `:issued`,
+      # and `:executed` values are always overridden to guard against
+      # an invalid definition.
       def create_registration_check(client)
         check = {:handler => "registration"}
         if client.has_key?(:registration)
@@ -44,11 +53,11 @@ module Sensu
         end
         timestamp = Time.now.to_i
         overrides = {
+          :name => "registration",
           :output => "new client registration",
           :status => 1,
           :issued => timestamp,
-          :executed => timestamp,
-          :handler => "registration"
+          :executed => timestamp
         }
         check.merge(overrides)
       end

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 10.3"
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "em-http-request", "~> 1.1"
+  s.add_development_dependency "addressable", "2.3.8"
 
   s.files         = Dir.glob("{exe,lib}/**/*") + %w[sensu.gemspec README.md CHANGELOG.md MIT-LICENSE.txt]
   s.executables   = s.files.grep(%r{^exe/}) { |file| File.basename(file) }

--- a/spec/config.json
+++ b/spec/config.json
@@ -41,6 +41,10 @@
         "debug"
       ]
     },
+    "registration": {
+      "type": "pipe",
+      "command": "cat > /tmp/sensu_client_registration.json"
+    },
     "file": {
       "type": "pipe",
       "command": "cat > /tmp/sensu_event"

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -44,7 +44,19 @@ describe "Sensu::Server::Process" do
               redis.get("client:i-424242") do |client_json|
                 client = MultiJson.load(client_json)
                 expect(client).to eq(keepalive)
-                async_done
+                read_event_file = Proc.new do
+                  begin
+                    event_file = IO.read("/tmp/sensu_client_registration.json")
+                    MultiJson.load(event_file)
+                  rescue
+                    retry
+                  end
+                end
+                compare_event_file = Proc.new do |event_file|
+                  expect(event_file[:check][:name]).to eq("registration")
+                  async_done
+                end
+                EM.defer(read_event_file, compare_event_file)
               end
             end
           end

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -54,6 +54,7 @@ describe "Sensu::Server::Process" do
                 end
                 compare_event_file = Proc.new do |event_file|
                   expect(event_file[:check][:name]).to eq("registration")
+                  expect(event_file[:client]).to eq(keepalive)
                   async_done
                 end
                 EM.defer(read_event_file, compare_event_file)


### PR DESCRIPTION
This PR allows for client registration event creation (and handling) when a sensu-client is first added to the registry. By default, client registration events use a handler named "registration". Clients can configure their own registration handler, e.g. `"registration": {"handler": "foo"}`.