### PR TITLE
Passing handlers when publishishing checks to clients

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -499,6 +499,7 @@ module Sensu
         payload[:command] = check[:command] if check.has_key?(:command)
         payload[:source] = check[:source] if check.has_key?(:source)
         payload[:extension] = check[:extension] if check.has_key?(:extension)
+        payload[:handlers] = check[:handlers] if check.has_key?(:handlers)
         @logger.info("publishing check request", {
           :payload => payload,
           :subscribers => check[:subscribers]


### PR DESCRIPTION
This is especially useful when a plugin creates multiple check events and feed them back to
sensu via the client socket. The plugin, when creating the event(s), can
optionally specify in the check metadata the same handlers as the original check.