### PR TITLE
Support client signatures

### DIFF
--- a/lib/sensu/api/process.rb
+++ b/lib/sensu/api/process.rb
@@ -449,6 +449,7 @@ module Sensu
                     settings.logger.info("deleting client from registry", :client_name => client_name)
                     settings.redis.srem("clients", client_name) do
                       settings.redis.del("client:#{client_name}")
+                      settings.redis.del("client:#{client_name}:signature")
                       settings.redis.del("events:#{client_name}")
                       settings.redis.smembers("result:#{client_name}") do |checks|
                         checks.each do |check_name|

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -77,7 +77,9 @@ module Sensu
       # check result is composed of a client (name) and a check
       # definition, containing check `:output` and `:status`. JSON
       # serialization is used when publishing the check result payload
-      # to the transport pipe. Transport errors are logged.
+      # to the transport pipe. The check result is signed with the
+      # client signature if configured, for source validation.
+      # Transport errors are logged.
       #
       # @param check [Hash]
       def publish_check_result(check)
@@ -85,6 +87,7 @@ module Sensu
           :client => @settings[:client][:name],
           :check => check
         }
+        payload[:signature] = @settings[:client][:signature] if @settings[:client][:signature]
         @logger.info("publishing check result", :payload => payload)
         @transport.publish(:direct, "results", MultiJson.dump(payload)) do |info|
           if info[:error]

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "multi_json", "1.11.2"
 gem "eventmachine", "1.0.8"
 
 gem "sensu-logger", "1.1.0"
-gem "sensu-settings", "3.1.0"
+gem "sensu-settings", "3.2.0"
 gem "sensu-extension", "1.3.0"
 gem "sensu-extensions", "1.4.0"
 gem "sensu-transport", "3.3.0"

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -87,6 +87,10 @@ module Sensu
       # @param client [Hash]
       # @param callback [Proc] to call after the the client data has
       #   been added to (or updated) the registry.
+      # @yield [success] passes success status to an optional
+      #   callback/block.
+      # @yieldparam success [TrueClass,FalseClass] if registry update
+      #   was a success.
       def update_client_registry(client, &callback)
         @logger.debug("updating client registry", :client => client)
         client_key = "client:#{client[:name]}"
@@ -100,7 +104,7 @@ module Sensu
             if signature.empty? || (client[:signature] == signature)
               @redis.set(client_key, MultiJson.dump(client)) do
                 @redis.sadd("clients", client[:name]) do
-                  callback.call(true)
+                  callback.call(true) if callback
                 end
               end
             else
@@ -109,7 +113,7 @@ module Sensu
                 :signature => signature
               })
               @logger.warn("not updating client in the registry", :client => client)
-              callback.call(false)
+              callback.call(false) if callback
             end
           end
         end

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -62,6 +62,13 @@ module Sensu
         check.merge(overrides)
       end
 
+      # Create and process a client registration event. A registration
+      # event is created each time a Sensu client is first added to
+      # the client registry. The `create_registration_check()` method
+      # is called to create a registration check definition for the
+      # client.
+      #
+      # @param client [Hash] definition.
       def create_client_registration_event(client)
         event = {
           :id => random_uuid,

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -85,12 +85,10 @@ module Sensu
       # used for the stored client data.
       #
       # @param client [Hash]
-      # @param callback [Proc] to call after the the client data has
-      #   been added to (or updated) the registry.
-      # @yield [success] passes success status to an optional
-      #   callback/block.
-      # @yieldparam success [TrueClass,FalseClass] if registry update
-      #   was a success.
+      # @param callback [Proc] to call with the success status
+      # (true/false) indicating if the client data has been added to
+      # (or updated) the registry or discarded due to client signature
+      # mismatch.
       def update_client_registry(client, &callback)
         @logger.debug("updating client registry", :client => client)
         client_key = "client:#{client[:name]}"
@@ -454,7 +452,9 @@ module Sensu
       # Retrieve a client (data) from Redis if it exists. If a client
       # does not already exist, create one (a blank) using the
       # `client_key` as the client name. Dynamically create client
-      # data can be updated using the API (POST /clients/:client).
+      # data can be updated using the API (POST /clients/:client). If
+      # a client does exist and it has a client signature, the check
+      # result must have a matching signature or it is discarded.
       #
       # @param result [Hash] data.
       # @param callback [Proc] to be called with client data, either
@@ -651,9 +651,11 @@ module Sensu
 
       # Publish a check result to the transport for processing. A
       # check result is composed of a client name and a check
-      # definition, containing check `:output` and `:status`. JSON
-      # serialization is used when publishing the check result payload
-      # to the transport pipe. Transport errors are logged.
+      # definition, containing check `:output` and `:status`. A client
+      # signature is added to the check result payload if one is
+      # registered for the client. JSON serialization is used when
+      # publishing the check result payload to the transport pipe.
+      # Transport errors are logged.
       #
       # @param client_name [String]
       # @param check [Hash]

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "uuidtools", "2.1.5"
   s.add_dependency "eventmachine", "1.0.8"
   s.add_dependency "sensu-logger", "1.1.0"
-  s.add_dependency "sensu-settings", "3.1.0"
+  s.add_dependency "sensu-settings", "3.2.0"
   s.add_dependency "sensu-extension", "1.3.0"
   s.add_dependency "sensu-extensions", "1.4.0"
   s.add_dependency "sensu-transport", "3.3.0"

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -392,6 +392,7 @@ describe "Sensu::Server::Process" do
       end
       timer(0.5) do
         @server.setup_transport
+        @server.setup_redis
         client = client_template
         check = result_template[:check]
         @server.publish_check_result(client[:name], check)


### PR DESCRIPTION
This feature & PR is based on the work done by @hany (https://github.com/sensu/sensu/pull/1125). 

Sensu clients can optionally set a `"signature"` in their definitions. A client signature is a unique string identifier, which is used to sign transport messages, for message source verification. Once a client signature is configured/set, the registered signature cannot be modified. A client must be deleted from the registry (via the API) in order to modify an existing client signature.

If a client has a signature, all keepalives and check results that it publishes must be signed with the correct signature or they will be discarded. This is not a replacement for other security measures.
