### PR TITLE
Handle checks with non integer ttl values

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -813,7 +813,7 @@ module Sensu
                     check = MultiJson.load(result_json)
                     next unless check[:ttl] && check[:executed] && !check[:force_resolve]
                     time_since_last_execution = Time.now.to_i - check[:executed]
-                    if time_since_last_execution >= check[:ttl]
+                    if time_since_last_execution >= check[:ttl].to_i
                       check[:output] = "Last check execution was "
                       check[:output] << "#{time_since_last_execution} seconds ago"
                       check[:status] = 1

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -557,6 +557,39 @@ describe "Sensu::Server::Process" do
     end
   end
 
+  it "can handle an invalid check ttl" do
+    async_wrapper do
+      @server.setup_redis
+      @server.setup_transport
+      @server.setup_results
+      redis.flushdb do
+        timer(1) do
+          client = client_template
+          redis.set("client:i-424242", MultiJson.dump(client)) do
+            redis.sadd("clients", "i-424242") do
+              result = result_template
+              result[:check][:name] = "foo"
+              result[:check][:ttl] = '30'
+              transport.publish(:direct, "results", MultiJson.dump(result))
+              timer(2) do
+                @server.determine_stale_check_results
+                timer(2) do
+                  redis.hgetall("events:i-424242") do |events|
+                    expect(events.size).to eq(1)
+                    event = MultiJson.load(events["foo"])
+                    expect(event[:check][:output]).to match(/Last check execution was 3[0-9] seconds ago/)
+                    expect(event[:check][:status]).to eq(1)
+                    async_done
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
   it "can prune aggregations" do
     async_wrapper do
       @server.setup_redis


### PR DESCRIPTION
fixes sensu/sensu#1182

If a user accidentally injects a string ttl value instead of an integer
it will crash the sensu server process.