### PR TITLE
Pull concurrent_workers setting from client settings

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -153,7 +153,7 @@ module Sensu
           if unmatched_tokens.empty?
             check[:executed] = Time.now.to_i
             started = Time.now.to_f
-            concurrency = @settings[:client].fetch(:concurrent_workers, 12)
+            concurrency = @settings[:eventmachine].fetch(:concurrent_workers, 12)
             spawn_opts = {:timeout => check[:timeout], :concurrency => concurrency}
             Spawn.process(command, spawn_opts) do |output, status|
               check[:duration] = ("%.3f" % (Time.now.to_f - started)).to_f

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -153,7 +153,9 @@ module Sensu
           if unmatched_tokens.empty?
             check[:executed] = Time.now.to_i
             started = Time.now.to_f
-            Spawn.process(command, :timeout => check[:timeout]) do |output, status|
+            concurrency = @settings[:client].fetch(:concurrent_workers, 12)
+            spawn_opts = {:timeout => check[:timeout], :concurrency => concurrency}
+            Spawn.process(command, spawn_opts) do |output, status|
               check[:duration] = ("%.3f" % (Time.now.to_f - started)).to_f
               check[:output] = output
               check[:status] = status

--- a/lib/sensu/server/handle.rb
+++ b/lib/sensu/server/handle.rb
@@ -30,8 +30,10 @@ module Sensu
       # @param event_data [Object] provided to the spawned handler
       #   process via STDIN.
       def pipe_handler(handler, event_data)
-        options = {:data => event_data, :timeout => handler[:timeout]}
-        Spawn.process(handler[:command], options) do |output, status|
+        concurrency = @settings[:eventmachine].fetch(:concurrent_workers, 12)
+        spawn_opts = {:data => event_data, :timeout => handler[:timeout],
+                      :concurrency => concurrency}
+        Spawn.process(handler[:command], spawn_opts) do |output, status|
           @logger.info("handler output", {
             :handler => handler,
             :output => output.split("\n+")

--- a/lib/sensu/server/mutate.rb
+++ b/lib/sensu/server/mutate.rb
@@ -40,7 +40,9 @@ module Sensu
       # @param callback [Proc] to call when the mutator executes
       #   successfully.
       def pipe_mutator(mutator, event, &callback)
-        options = {:data => MultiJson.dump(event), :timeout => mutator[:timeout]}
+        concurrency = @settings[:eventmachine].fetch(:concurrent_workers, 12)
+        spawn_opts = {:data => MultiJson.dump(event), :timeout => mutator[:timeout],
+                      :concurrency => concurrency}
         block = mutator_callback(mutator, event, &callback)
         Spawn.process(mutator[:command], options, &block)
       end

--- a/lib/sensu/server/mutate.rb
+++ b/lib/sensu/server/mutate.rb
@@ -44,7 +44,7 @@ module Sensu
         spawn_opts = {:data => MultiJson.dump(event), :timeout => mutator[:timeout],
                       :concurrency => concurrency}
         block = mutator_callback(mutator, event, &callback)
-        Spawn.process(mutator[:command], options, &block)
+        Spawn.process(mutator[:command], spawn_opts, &block)
       end
 
       # Run a mutator extension, within the Sensu EventMachine reactor


### PR DESCRIPTION
Allows sensu clients to set the max number of concurrent event machine workers.

Needs this pull request as well: https://github.com/sensu/sensu-spawn/pull/12

Resolves sensu/sensu#1184 