### PR TITLE
deregister event

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -381,6 +381,23 @@ module Sensu
         end
       end
 
+      # Sends a deregister event to be processed by sensu server
+      def send_deregister_event
+        if @settings[:client][:deregister_handler].nil?
+          @logger.warn("deregister enabled but no handler passed, not sending event")
+        else
+          @logger.info("sending deregister event to #{@settings[:client][:deregister_handler]}")
+          check = {
+            :name => 'deregister',
+            :output => 'delete client as a result of clean shutdown',
+            :process => 'init',
+            :status => 1,
+            :handler => @settings[:client][:deregister_handler]
+          }
+          publish_check_result(check)
+        end
+      end
+
       # Close the Sensu client TCP and UDP sockets. This method
       # iterates through `@sockets`, which contains socket server
       # signatures (Fixnum) and connection objects. A signature
@@ -455,9 +472,11 @@ module Sensu
       # Stop the Sensu client process, pausing it, completing check
       # executions in progress, closing the transport connection, and
       # exiting the process (exit 0). After pausing the process, the
-      # process/daemon `@state` is set to `:stopping`.
+      # process/daemon `@state` is set to `:stopping`.  Also sends
+      # deregister event if configured to do so.
       def stop
         @logger.warn("stopping")
+        send_deregister_event if @settings[:client][:deregister] == true
         pause
         @state = :stopping
         complete_checks_in_progress do

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -65,6 +65,23 @@ describe "Sensu::Client::Process" do
     end
   end
 
+  it "can send a deregister event" do
+    async_wrapper do
+      result_queue do |payload|
+        result = MultiJson.load(payload)
+        expect(result[:client]).to eq("i-424242")
+        expect(result[:check][:name]).to eq("deregister")
+        expect(result[:check][:status]).to eq(1)
+        expect(result[:check][:handler]).to eq("DEREGISTER_HANDLER")
+        async_done
+      end
+      timer(0.5) do
+        @client.setup_transport
+        @client.send_deregister_event
+      end
+    end
+  end
+
   it "can execute a check command" do
     async_wrapper do
       result_queue do |payload|

--- a/spec/config.json
+++ b/spec/config.json
@@ -165,6 +165,8 @@
         "warning": 10
       }
     },
+    "deregister": true,
+    "deregister_handler": "DEREGISTER_HANDLER",
     "version": "TOBEREPLACED",
     "nested": {
       "attribute": true


### PR DESCRIPTION
Wanted to move the deregister event inside of the sensu client instead of the init script.  That way its easy to configure via the puppet module.

Since the register event is also configured via the client, I think it makes more sense to have both live inside of the code.