### PR TITLE
Support token substitution in filter eval attributes

### DIFF
--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -167,6 +167,16 @@ module Sensu
         end
       end
 
+      # Process a filter eval attribute, a Ruby `eval()` string
+      # containing an expression to be evaluated within the
+      # scope/context of a sandbox. This methods strips away the
+      # expression prefix, `eval:`, and substitues any dot notation
+      # tokens with the corresponding event data values. If there are
+      # unmatched tokens, this method will return `nil`.
+      #
+      # @event [Hash]
+      # @raw_eval_string [String]
+      # @return [String] processed eval string.
       def process_eval_string(event, raw_eval_string)
         eval_string = raw_eval_string.slice(5..-1)
         eval_string, unmatched_tokens = substitute_tokens(eval_string, event)
@@ -182,7 +192,7 @@ module Sensu
         end
       end
 
-      # Ruby eval() a string containing an expression, within the
+      # Ruby `eval()` a string containing an expression, within the
       # scope/context of a sandbox. This method is for filter
       # attribute values starting with "eval:", with the Ruby
       # expression following the colon. A single variable is provided

--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -275,7 +275,7 @@ module Sensu
         case
         when @settings.filter_exists?(filter_name)
           filter = @settings[:filters][filter_name]
-          matched = filter_attributes_match?(event, filter[:attributes], event)
+          matched = filter_attributes_match?(event, filter[:attributes])
           yield(filter[:negate] ? matched : !matched)
         when @extensions.filter_exists?(filter_name)
           extension = @extensions[:filters][filter_name]

--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -89,7 +89,7 @@ module Sensu
     # @param default [Object] value if attribute value is nil.
     # @return [Object] attribute or fallback default value.
     def find_attribute_value(tree, path, default)
-      attribute = tree[path.shift]
+      attribute = tree[path.shift.to_sym]
       if attribute.is_a?(Hash)
         find_attribute_value(attribute, path, default)
       else

--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -89,7 +89,7 @@ module Sensu
     # @param default [Object] value if attribute value is nil.
     # @return [Object] attribute or fallback default value.
     def find_attribute_value(tree, path, default)
-      attribute = tree[path.shift.to_sym]
+      attribute = tree[path.shift]
       if attribute.is_a?(Hash)
         find_attribute_value(attribute, path, default)
       else
@@ -109,7 +109,8 @@ module Sensu
       unmatched_tokens = []
       substituted = tokens.gsub(/:::([^:].*?):::/) do
         token, default = $1.to_s.split("|", -1)
-        matched = find_attribute_value(attributes, token.split("."), default)
+        path = token.split(".").map(&:to_sym)
+        matched = find_attribute_value(attributes, path, default)
         if matched.nil?
           unmatched_tokens << token
         end

--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -80,5 +80,42 @@ module Sensu
       end
       hash
     end
+
+    # Traverse a hash for an attribute value, with a fallback default
+    # value if nil.
+    #
+    # @param tree [Hash] to traverse.
+    # @param path [Array] of attribute keys.
+    # @param default [Object] value if attribute value is nil.
+    # @return [Object] attribute or fallback default value.
+    def find_attribute_value(tree, path, default)
+      attribute = tree[path.shift]
+      if attribute.is_a?(Hash)
+        find_attribute_value(attribute, path, default)
+      else
+        attribute.nil? ? default : attribute
+      end
+    end
+
+    # Substitute dot notation tokens (eg. :::db.name|production:::)
+    # with the associated definition attribute value. Tokens can
+    # provide a fallback default value, following a pipe.
+    #
+    # @param tokens [String]
+    # @param attributes [Hash]
+    # @return [Array] containing the string with tokens substituted
+    #   and an array of unmatched tokens.
+    def substitute_tokens(tokens, attributes)
+      unmatched_tokens = []
+      substituted = tokens.gsub(/:::([^:].*?):::/) do
+        token, default = $1.to_s.split("|", -1)
+        matched = find_attribute_value(attributes, token.split("."), default)
+        if matched.nil?
+          unmatched_tokens << token
+        end
+        matched
+      end
+      [substituted, unmatched_tokens]
+    end
   end
 end

--- a/spec/server/filter_spec.rb
+++ b/spec/server/filter_spec.rb
@@ -136,21 +136,21 @@ describe "Sensu::Server::Filter" do
       :occurrences => 1,
       :action => "resolve"
     }
-    expect(@server.filter_attributes_match?(attributes, @event)).to be(false)
+    expect(@server.filter_attributes_match?(@event, attributes)).to be(false)
     attributes[:action] = "create"
-    expect(@server.filter_attributes_match?(attributes, @event)).to be(true)
+    expect(@server.filter_attributes_match?(@event, attributes)).to be(true)
     @event[:occurrences] = 2
-    expect(@server.filter_attributes_match?(attributes, @event)).to be(false)
+    expect(@server.filter_attributes_match?(@event, attributes)).to be(false)
     attributes[:occurrences] = "eval: value == 1 || value % 60 == 0"
     @event[:occurrences] = 1
-    expect(@server.filter_attributes_match?(attributes, @event)).to be(true)
+    expect(@server.filter_attributes_match?(@event, attributes)).to be(true)
     attributes[:occurrences] = "eval: value == '\neval:'.size || value % 60 == 0"
     @event[:occurrences] = "\neval:".size
-    expect(@server.filter_attributes_match?(attributes, @event)).to be(true)
+    expect(@server.filter_attributes_match?(@event, attributes)).to be(true)
     @event[:occurrences] = 2
-    expect(@server.filter_attributes_match?(attributes, @event)).to be(false)
+    expect(@server.filter_attributes_match?(@event, attributes)).to be(false)
     @event[:occurrences] = 120
-    expect(@server.filter_attributes_match?(attributes, @event)).to be(true)
+    expect(@server.filter_attributes_match?(@event, attributes)).to be(true)
   end
 
   it "can filter an event using a filter" do

--- a/spec/server/filter_spec.rb
+++ b/spec/server/filter_spec.rb
@@ -141,15 +141,27 @@ describe "Sensu::Server::Filter" do
     expect(@server.filter_attributes_match?(@event, attributes)).to be(true)
     @event[:occurrences] = 2
     expect(@server.filter_attributes_match?(@event, attributes)).to be(false)
-    attributes[:occurrences] = "eval: value == 1 || value % 60 == 0"
-    @event[:occurrences] = 1
+  end
+
+  it "can determine if filter eval attributes match an event" do
+    attributes = {
+      :occurrences => "eval: value == 3 || value % 60 == 0"
+    }
+    expect(@server.filter_attributes_match?(@event, attributes)).to be(false)
+    @event[:occurrences] = 3
     expect(@server.filter_attributes_match?(@event, attributes)).to be(true)
-    attributes[:occurrences] = "eval: value == '\neval:'.size || value % 60 == 0"
-    @event[:occurrences] = "\neval:".size
-    expect(@server.filter_attributes_match?(@event, attributes)).to be(true)
-    @event[:occurrences] = 2
+    @event[:occurrences] = 4
     expect(@server.filter_attributes_match?(@event, attributes)).to be(false)
     @event[:occurrences] = 120
+    expect(@server.filter_attributes_match?(@event, attributes)).to be(true)
+    @event[:occurrences] = 3
+    attributes[:occurrences] = "eval: value == :::check.occurrences:::"
+    expect(@server.filter_attributes_match?(@event, attributes)).to be(false)
+    attributes[:occurrences] = "eval: value == :::check.occurrences|3:::"
+    expect(@server.filter_attributes_match?(@event, attributes)).to be(true)
+    @event[:check][:occurrences] = 2
+    expect(@server.filter_attributes_match?(@event, attributes)).to be(false)
+    @event[:occurrences] = 2
     expect(@server.filter_attributes_match?(@event, attributes)).to be(true)
   end
 

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -88,4 +88,19 @@ describe "Sensu::Utilities" do
     expect(redacted[:diff_two][0][:secret]).to eq("REDACTED")
     expect(redacted[:diff_two][1][:secret]).to eq("REDACTED")
   end
+
+  it "can substitute dot notation tokens" do
+    string = ":::nested.attribute|default::: :::missing|default:::"
+    string << " :::missing|::: :::missing::: :::nested.attribute:::::::nested.attribute:::"
+    string << " :::empty|localhost::: :::empty.hash|localhost:8080:::"
+    attributes = {
+      :nested => {
+        :attribute => true
+      },
+      :empty => {}
+    }
+    result, unmatched_tokens = substitute_tokens(string, attributes)
+    expect(result).to eq("true default   true:true localhost localhost:8080")
+    expect(unmatched_tokens).to eq(["missing"])
+  end
 end


### PR DESCRIPTION
Possible solution for: https://trello.com/c/QDqdU5kk/79-new-support-for-filter-eval-token-substitution

A top level `"eval":` setting tends to produce Ruby eval() strings that are long and difficult to read, as conditionals grow, e.g. `&& ||`. This PR adds token support to the existing filter eval attribute feature, promoting more concise filter definitions.

Example:

```
"attributes": {
  "occurrences": "eval: value == :::check.occurrences::: || value % 60 == 0"
}
```

![1359](https://cloud.githubusercontent.com/assets/149630/14028933/853b471c-f1bc-11e5-9770-11e7a9442fbb.gif)
