### PR TITLE
Set the check interval to 30s for stale ttl events

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -953,6 +953,7 @@ module Sensu
                   client_name = result_key.split(":").first
                   keepalive_event_exists?(client_name) do |event_exists|
                     unless event_exists
+                      check[:interval] = 30
                       check[:output] = "Last check execution was "
                       check[:output] << "#{time_since_last_execution} seconds ago"
                       check[:status] = 1


### PR DESCRIPTION
At Yelp we make heavy use of the TTL stale-check feature.

We also use advanced filtering logic based on the config of the check.

The problem comes when there is a mismatch between the original configuration of a check (maybe it runs every 24hs), and when it run in "stale ttl mode" (which is 30s)

This patch makes it so the stale ttl thing correctly sets the "real" interval when it is in this mode, which will give our handlers better hints about how frequently to anticipate this event.
