### PR TITLE
Include an executed_command attribute in check results

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -120,6 +120,7 @@ module Sensu
             Spawn.process(command, :timeout => check[:timeout]) do |output, status|
               check[:duration] = ("%.3f" % (Time.now.to_f - started)).to_f
               check[:output] = output
+              check[:executed_command] = command
               check[:status] = status
               publish_check_result(check)
               @checks_in_progress.delete(check[:name])


### PR DESCRIPTION
I've caught myself a few times getting hung up on troubleshooting the effects of command token substitution in my check definitions. Check results and events will show the defined check `command` with the token, but they don't show the command the client actually executes. 

In my most recent experience, I was configuring a client to use command token substitution with the `check-http.rb` plugin, as follows: 

~~~
{
  "checks": {
    "sensu-website": {
      "command": "check-http.rb -u :::website|https://sensuapp.org:::",
      "subscribers": [
        "documentation"
      ],
      "interval": 60
    }
  }
}
~~~

Unfortunately, the `check-http.rb` plugin doesn't include any information about the url it queries - just the HTTP response code. So I kept having to double check that my configuration was correct. With this PR, that would have been unnecessary, because the output will make it obvious: 

~~~
$ curl -s http://localhost:4567/results/client-01/sensu_website | jq .
{
  "check": {
    "status": 0,
    "executed_command": "check-http.rb -u http://www.google.com",
    "command": "check-http.rb -u :::website|https://sensuapp.org:::",
    "subscribers": [
      "documentation"
    ],
    "interval": 60,
    "name": "sensu_website",
    "issued": 1460264802,
    "executed": 1460264802,
    "duration": 0.454,
    "output": "CheckHttp OK: 200, 19105 bytes\n"
  },
  "client": "client-01"
}
~~~

...and my client configuration: 

~~~
$ curl -s http://localhost:4567/clients/client-01 | jq .
{
  "timestamp": 1460264848,
  "version": "0.23.0",
  "website": "http://www.google.com",
  "socket": {
    "port": 3030,
    "bind": "127.0.0.1"
  },
  "subscriptions": [
    "documentation"
  ],
  "environment": "development",
  "address": "127.0.0.1",
  "name": "client-01"
}
~~~

I will be surprised if this hasn't been recommended before, which also means I will not be surprised if there's a perfectly reasonable explanation for _not_ merging this. Looking forward to feedback/input. :smile: 
