### PR TITLE
Support multiple tokens where token substitution is allowed

### DIFF
--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -108,13 +108,18 @@ module Sensu
     def substitute_tokens(tokens, attributes)
       unmatched_tokens = []
       substituted = tokens.gsub(/:::([^:].*?):::/) do
-        token, default = $1.to_s.split("|", -1)
-        path = token.split(".").map(&:to_sym)
-        matched = find_attribute_value(attributes, path, default)
-        if matched.nil?
-          unmatched_tokens << token
+        token = $1.to_s.split("|", -1)
+        default = token.length > 1 ? token.pop : nil
+        matched = nil
+        token.each do |t|
+          path = t.split(".").map(&:to_sym)
+          matched = find_attribute_value(attributes, path, default)
+          if matched.nil?
+            unmatched_tokens << t
+          end
+          matched
         end
-        matched
+        matched || default
       end
       [substituted, unmatched_tokens]
     end


### PR DESCRIPTION
First of all, let me post a selfie: 

![](http://memesvault.com/wp-content/uploads/I-Have-No-Idea-What-Im-Doing-Dog-02.jpg)

...now that I've got that out of the way, I think it would be super useful if multiple tokens could be used instead of just a token and a default value &mdash; especially with the new support for [filter attribute eval tokens][1] in 0.23. Also, I think there are a few other related improvements we could implement in Sensu that would also benefit from improvements to the shared token substitution utility. 

Supporting multiple tokens would allow token definitions like: 

`:::check.my_attribute|client.my_attribute|default:::` 

...instead of just one token and a default value:

`:::check.my_attribute|default:::`. 

Please feel free to insult this PRs children, because I know the ruby is pretty derpy, but I got it working well enough to use it in a testing environment so I wanted to open a PR for discussion. I'm open to any feedback that could make this better. :smile: 

[1]:  https://sensuapp.org/docs/latest/filters#filter-attribute-eval-tokens