### PR TITLE
Consistent & strong validation for files & definitions, --validate_config

### DIFF
--- a/lib/sensu/cli.rb
+++ b/lib/sensu/cli.rb
@@ -26,6 +26,9 @@ module Sensu
         opts.on("-d", "--config_dir DIR[,DIR]", "DIR or comma-delimited DIR list for Sensu JSON config files") do |dir|
           options[:config_dirs] = dir.split(",")
         end
+        opts.on("--validate_config", "Validate the compiled configuration and exit") do
+          options[:validate_config] = true
+        end
         opts.on("-P", "--print_config", "Print the compiled configuration and exit") do
           options[:print_config] = true
         end

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -85,12 +85,12 @@ module Sensu
     #
     # @param settings [Object]
     def validate_settings!(settings)
-      @logger.info("validating latest configuration")
       if settings.errors.empty?
-        @logger.info("latest configuration is valid")
+        puts "configuration is valid"
         exit
       else
-        @logger.fatal("latest configuration is invalid", :errors => @settings.errors)
+        puts "configuration is invalid"
+        puts Sensu::JSON.dump({:errors => @settings.errors}, :pretty => true)
         exit 2
       end
     end

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.0.1"
 
 gem "sensu-json", "1.1.1"
 gem "sensu-logger", "1.2.0"
-gem "sensu-settings", "3.4.0"
+gem "sensu-settings", "4.0.0"
 gem "sensu-extension", "1.5.0"
 gem "sensu-extensions", "1.5.0"
 gem "sensu-transport", "5.0.0"
@@ -64,56 +64,78 @@ module Sensu
       @logger.setup_signal_traps
     end
 
-    # Log setting or extension loading concerns, sensitive information
+    # Log setting or extension loading notices, sensitive information
     # is redacted.
     #
-    # @param concerns [Array] to be logged.
-    # @param level [Symbol] to log the concerns at.
-    def log_concerns(concerns=[], level=:warn)
-      concerns.each do |concern|
+    # @param notices [Array] to be logged.
+    # @param level [Symbol] to log the notices at.
+    def log_notices(notices=[], level=:warn)
+      notices.each do |concern|
         message = concern.delete(:message)
         @logger.send(level, message, redact_sensitive(concern))
       end
     end
 
-    # Print the Sensu settings and immediately exit the process. This
-    # method is used while troubleshooting configuration issues,
-    # triggered by a CLI argument, e.g. `--print_config`. Sensu
-    # settings with sensitive values (e.g. passwords) are first
-    # redacted.
+    # Determine if the Sensu settings are valid, if there are load or
+    # validation errors, and immediately exit the process with the
+    # appropriate exit status code. This method is used to determine
+    # if the latest configuration changes are valid prior to
+    # restarting the Sensu service, triggered by a CLI argument, e.g.
+    # `--validate_config`.
     #
     # @param settings [Object]
-    def print_settings(settings)
+    def validate_settings!(settings)
+      @logger.info("validating latest configuration")
+      if settings.errors.empty?
+        @logger.info("latest configuration is valid")
+        exit
+      else
+        @logger.fatal("latest configuration is invalid", :errors => @settings.errors)
+        exit 2
+      end
+    end
+
+    # Print the Sensu settings (JSON) to STDOUT and immediately exit
+    # the process with the appropriate exit status code. This method
+    # is used while troubleshooting configuration issues, triggered by
+    # a CLI argument, e.g. `--print_config`. Sensu settings with
+    # sensitive values (e.g. passwords) are first redacted.
+    #
+    # @param settings [Object]
+    def print_settings!(settings)
       redacted_settings = redact_sensitive(settings.to_hash)
       @logger.warn("outputting compiled configuration and exiting")
       puts Sensu::JSON.dump(redacted_settings, :pretty => true)
-      exit
+      exit(settings.errors.empty? ? 0 : 2)
     end
 
-    # Load Sensu settings and validate them. If there are validation
-    # failures, log them (concerns), then cause the Sensu process to
-    # exit (2). This method creates the settings instance variable:
-    # `@settings`. If the `print_config` option is true, this method
-    # calls `print_settings()` to output the compiled configuration
-    # settings and then exit the process.
+    # Load Sensu settings. This method creates the settings instance
+    # variable: `@settings`. If the `validate_config` option is true,
+    # this method calls `validate_settings!()` to validate the latest
+    # compiled configuration settings and will then exit the process.
+    # If the `print_config` option is true, this method calls
+    # `print_settings!()` to output the compiled configuration
+    # settings and will then exit the process. If there are loading or
+    # validation errors, they will be logged (notices), and this
+    # method will exit(2) the process.
+    #
     #
     # https://github.com/sensu/sensu-settings
     #
     # @param options [Hash]
     def load_settings(options={})
       @settings = Settings.get(options)
-      log_concerns(@settings.warnings)
-      failures = @settings.validate
-      unless failures.empty?
-        @logger.fatal("invalid settings")
-        log_concerns(failures, :fatal)
+      validate_settings!(@settings) if options[:validate_config]
+      log_notices(@settings.warnings)
+      log_notices(@settings.errors, :fatal)
+      print_settings!(@settings) if options[:print_config]
+      unless @settings.errors.empty?
         @logger.fatal("SENSU NOT RUNNING!")
         exit 2
       end
-      print_settings(@settings) if options[:print_config]
     end
 
-    # Load Sensu extensions and log any concerns. Set the logger and
+    # Load Sensu extensions and log any notices. Set the logger and
     # settings for each extension instance. This method creates the
     # extensions instance variable: `@extensions`.
     #
@@ -123,7 +145,7 @@ module Sensu
     # @param options [Hash]
     def load_extensions(options={})
       @extensions = Extensions.get(options)
-      log_concerns(@extensions.warnings)
+      log_notices(@extensions.warnings)
       extension_settings = @settings.to_hash.dup
       @extensions.all.each do |extension|
         extension.logger = @logger

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.0.1"
   s.add_dependency "sensu-json", "1.1.1"
   s.add_dependency "sensu-logger", "1.2.0"
-  s.add_dependency "sensu-settings", "3.4.0"
+  s.add_dependency "sensu-settings", "4.0.0"
   s.add_dependency "sensu-extension", "1.5.0"
   s.add_dependency "sensu-extensions", "1.5.0"
   s.add_dependency "sensu-transport", "5.0.0"


### PR DESCRIPTION
This PR applies consistent strong configuration validation, for file loading and definition validation errors alike. This PR also adds the CLI argument/option `--validate_config`, which can be used to validate Sensu's latest configuration (on disk) prior to restarting the active Sensu service.

This PR closes https://github.com/sensu/sensu/issues/1244

Example `--validate_config` output:

```
$ bundle exec ./exe/sensu-client -c spec/config.json -d spec/conf.d --validate_config
configuration is valid
$ echo $?
0
$ emacs spec/config.json 
$ bundle exec ./exe/sensu-client -c spec/config.json -d spec/conf.d --validate_config
configuration is invalid
{
  "errors":[
    {
      "message":"config file must be valid json",
      "file":"spec/config.json",
      "error":"expected comma, not a string at line 6, column 11 [parse.c:381]"
    }
  ]
}
$ echo $?
2
```