### PR TITLE
Keep track of results being processed

### DIFF
--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -345,14 +345,14 @@ module Sensu
         end
         if filter_message
           @logger.info(filter_message, details)
-          @handling_event_count -= 1 if @handling_event_count
+          @in_progress[:events] -= 1 if @in_progress
         else
           event_filtered?(handler, event) do |filtered|
             unless filtered
               yield(event)
             else
               @logger.info("event was filtered", details)
-              @handling_event_count -= 1 if @handling_event_count
+              @in_progress[:events] -= 1 if @in_progress
             end
           end
         end

--- a/lib/sensu/server/mutate.rb
+++ b/lib/sensu/server/mutate.rb
@@ -6,7 +6,7 @@ module Sensu
       # created callback can be used for standard mutators and mutator
       # extensions. The provided callback will only be called when the
       # mutator status is `0` (OK). If the status is not `0`, an error
-      # is logged, and the `@handling_event_count` is decremented by
+      # is logged, and the `@in_progress[:events]` is decremented by
       # `1`.
       #
       # @param mutator [Object] definition or extension.
@@ -25,7 +25,7 @@ module Sensu
               :output => output,
               :status => status
             })
-            @handling_event_count -= 1 if @handling_event_count
+            @in_progress[:events] -= 1 if @in_progress
           end
         end
       end
@@ -63,7 +63,7 @@ module Sensu
       # mutator is used, unless the handler specifies another mutator.
       # If a mutator does not exist, not defined or a missing
       # extension, an error will be logged and the
-      # `@handling_event_count` is decremented by `1`. This method
+      # `@in_progress[:events]` is decremented by `1`. This method
       # first checks for the existence of a standard mutator, then
       # checks for an extension if a standard mutator is not defined.
       #
@@ -84,7 +84,7 @@ module Sensu
           @logger.error("unknown mutator", {
             :mutator_name => mutator_name
           })
-          @handling_event_count -= 1 if @handling_event_count
+          @in_progress[:events] -= 1 if @in_progress
         end
       end
     end

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -55,7 +55,7 @@ module Sensu
         setup_redis do
           @redis.on_error do |error|
             @logger.error("redis connection error", :error => error.to_s)
-            @in_progress[:results] = 0
+            @in_progress[:check_results] = 0
           end
           setup_transport do
             yield


### PR DESCRIPTION
This PR adds the ability to track in progress check result processing, prior to the event handling hand-off, to reduce potential data loss during process restarts etc.

- closes https://github.com/sensu/sensu/issues/1165

Works with in progress check result -> event :+1:

```
{"timestamp":"2016-05-09T09:37:59.684702-0700","level":"info","message":"completing work in progress","in_progress":{"check_results":1,"events":0}}
{"timestamp":"2016-05-09T09:37:59.684880-0700","level":"info","message":"processing event","event":{"id":"a1e53e3d-70c6-47f0-8836-b31dc8e3311f","client":{"name":"i-424242","address":"127.0.0.1","subscriptions":["test","roundrobin:test","all"],"keepalive":{"thresholds":{"warning":10}},"version":"0.23.2","nested":{"attribute":true},"service":{"password":"REDACTED"},"empty":{},"localhost":"fail","timestamp":1462811832},"check":{"name":"foobar","output":"baz","status":1,"handler":"noop","executed":1462811879,"issued":1462811879,"history":["1","1","1","1","1","1","1","1","1","1","1","1","1","1","1","1","1","1","1","1","1"],"total_state_change":0},"occurrences":4914,"action":"create","timestamp":1462811879}}
{"timestamp":"2016-05-09T09:37:59.684932-0700","level":"error","message":"unknown handler","handler_name":"noop"}
{"timestamp":"2016-05-09T09:38:00.185345-0700","level":"warn","message":"stopping reactor"}
```