### PR TITLE
Improve check TTL monitoring

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -346,6 +346,7 @@ module Sensu
         @redis.multi
         @redis.sadd("result:#{client[:name]}", check[:name])
         @redis.set("result:#{result_key}", Sensu::JSON.dump(check_truncated))
+        @redis.sadd("ttl", result_key) if check[:ttl]
         @redis.rpush(history_key, check[:status])
         @redis.ltrim(history_key, -21, -1)
         @redis.exec do
@@ -878,24 +879,22 @@ module Sensu
       # published with the appropriate check output.
       def determine_stale_check_results
         @logger.info("determining stale check results")
-        @redis.smembers("clients") do |clients|
-          clients.each do |client_name|
-            @redis.smembers("result:#{client_name}") do |checks|
-              checks.each do |check_name|
-                result_key = "#{client_name}:#{check_name}"
-                @redis.get("result:#{result_key}") do |result_json|
-                  unless result_json.nil?
-                    check = Sensu::JSON.load(result_json)
-                    next unless check[:ttl] && check[:executed] && !check[:force_resolve]
-                    time_since_last_execution = Time.now.to_i - check[:executed]
-                    if time_since_last_execution >= check[:ttl]
-                      check[:output] = "Last check execution was "
-                      check[:output] << "#{time_since_last_execution} seconds ago"
-                      check[:status] = 1
-                      publish_check_result(client_name, check)
-                    end
-                  end
+        @redis.smembers("ttl") do |result_keys|
+          result_keys.each do |result_key|
+            @redis.get("result:#{result_key}") do |result_json|
+              unless result_json.nil?
+                check = Sensu::JSON.load(result_json)
+                next unless check[:ttl] && check[:executed] && !check[:force_resolve]
+                time_since_last_execution = Time.now.to_i - check[:executed]
+                if time_since_last_execution >= check[:ttl]
+                  client_name = result_key.split(":").first
+                  check[:output] = "Last check execution was "
+                  check[:output] << "#{time_since_last_execution} seconds ago"
+                  check[:status] = 1
+                  publish_check_result(client_name, check)
                 end
+              else
+                @redis.srem("ttl", result_key)
               end
             end
           end

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -871,12 +871,11 @@ module Sensu
 
       # Determine stale check results, those that have not executed in
       # a specified amount of time (check TTL). This method iterates
-      # through the client registry and check results for checks with
-      # a defined TTL value (in seconds). If a check result has a
-      # defined TTL, the time since last check execution (in seconds)
-      # is calculated. If the time since last execution is equal to or
-      # greater than the check TTL, a warning check result is
-      # published with the appropriate check output.
+      # through stored check results that have a defined TTL value (in
+      # seconds). The time since last check execution (in seconds) is
+      # calculated for each check result. If the time since last
+      # execution is equal to or greater than the check TTL, a warning
+      # check result is published with the appropriate check output.
       def determine_stale_check_results
         @logger.info("determining stale check results")
         @redis.smembers("ttl") do |result_keys|


### PR DESCRIPTION
The current method of monitoring for stale check results (check TTLs), runs every 30 seconds on the Sensu server leader, walking the entire client registry and all associated stored check results. This is insane.

This pull requests eliminates the need to walk the client registry and stored check results.

![unnamed](https://cloud.githubusercontent.com/assets/149630/15557827/6c625290-228a-11e6-9e7e-d4e46f29c34d.gif)

