### PR TITLE
API, check connections on request

### DIFF
--- a/lib/sensu/api/process.rb
+++ b/lib/sensu/api/process.rb
@@ -315,7 +315,7 @@ module Sensu
         settings.cors.each do |header, value|
           headers["Access-Control-Allow-#{header}"] = value
         end
-        error! unless connected?
+        error! unless connected? || %w[/info /health].include?(env["REQUEST_PATH"])
         protected! unless env["REQUEST_METHOD"] == "OPTIONS"
       end
 


### PR DESCRIPTION
This PR allows the API to start listening immediately, potentially before it connects to Redis and the Sensu Transport. If the API receives a request before it connects to Redis and the Transport, it will return a 500 (error). If the API receives a request while it is reconnecting to either (or both) Redis or the Transport, it will return a 500 (error). `/info` and `/health` are excluded from reconnecting case.

Closes https://github.com/sensu/sensu/issues/1215