### PR TITLE
Implement optional deregistration in client process

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -381,7 +381,9 @@ module Sensu
       # configuration, it's deep merged with the defaults. The
       # check `:name`, `:output`, `:status`, `:issued`, and
       # `:executed` values are always overridden to guard against
-      # an invalid definition.
+      # an invalid definition. The check `:interval` and `:refresh`
+      # values are always overridden to guard against deregistration
+      # events being filtered out by the server.
       def send_deregister_event
         check = {:handler => "deregistration"}
         if @settings[:client].has_key?(:deregistration)

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -393,7 +393,9 @@ module Sensu
           :output => "client initiated deregistration",
           :status => 1,
           :issued => timestamp,
-          :executed => timestamp
+          :executed => timestamp,
+          :interval => 1,
+          :refresh => 1
         }
         publish_check_result(check.merge(overrides))
       end

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -376,7 +376,7 @@ module Sensu
       # Create a check result intended for deregistering a client.
       # Client definitions may contain `:deregistration` configuration,
       # containing custom attributes and handler information. By
-      # default, the deregistration event sets the `:handler` to
+      # default, the deregistration check result sets the `:handler` to
       # `deregistration`. If the client provides its own `:deregistration`
       # configuration, it's deep merged with the defaults. The
       # check `:name`, `:output`, `:status`, `:issued`, and
@@ -474,7 +474,7 @@ module Sensu
       # executions in progress, closing the transport connection, and
       # exiting the process (exit 0). After pausing the process, the
       # process/daemon `@state` is set to `:stopping`.  Also sends
-      # deregister event if configured to do so.
+      # deregistration check result if configured to do so.
       def stop
         @logger.warn("stopping")
         pause

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -481,8 +481,8 @@ module Sensu
       # deregister event if configured to do so.
       def stop
         @logger.warn("stopping")
-        send_deregister_event if @settings[:client][:deregister] == true
         pause
+        send_deregister_event if @settings[:client][:deregister] == true
         @state = :stopping
         complete_checks_in_progress do
           close_sockets

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -68,6 +68,23 @@ describe "Sensu::Client::Process" do
     end
   end
 
+  it "can send a deregister event" do
+    async_wrapper do
+      result_queue do |payload|
+        result = MultiJson.load(payload)
+        expect(result[:client]).to eq("i-424242")
+        expect(result[:check][:name]).to eq("deregister")
+        expect(result[:check][:status]).to eq(1)
+        expect(result[:check][:handler]).to eq("DEREGISTER_HANDLER")
+        async_done
+      end
+      timer(0.5) do
+        @client.setup_transport
+        @client.send_deregister_event
+      end
+    end
+  end
+
   it "can execute a check command" do
     async_wrapper do
       result_queue do |payload|

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -76,6 +76,8 @@ describe "Sensu::Client::Process" do
         expect(result[:check][:name]).to eq("deregistration")
         expect(result[:check][:status]).to eq(1)
         expect(result[:check][:handler]).to eq("DEREGISTER_HANDLER")
+        expect(result[:check][:interval]).to eq(1)
+        expect(result[:check][:refresh]).to eq(1)
         async_done
       end
       timer(0.5) do

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -77,12 +77,11 @@ describe "Sensu::Client::Process" do
         expect(result[:check][:status]).to eq(1)
         expect(result[:check][:handler]).to eq("DEREGISTER_HANDLER")
         expect(result[:check][:interval]).to eq(1)
-        expect(result[:check][:refresh]).to eq(1)
         async_done
       end
       timer(0.5) do
         @client.setup_transport do
-          @client.send_deregister_event
+          @client.deregister
         end
       end
     end

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -68,7 +68,7 @@ describe "Sensu::Client::Process" do
     end
   end
 
-  it "can send a deregistraion event" do
+  it "can send a deregistraion check result" do
     async_wrapper do
       result_queue do |payload|
         result = Sensu::JSON.load(payload)

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -68,19 +68,20 @@ describe "Sensu::Client::Process" do
     end
   end
 
-  it "can send a deregister event" do
+  it "can send a deregistraion event" do
     async_wrapper do
       result_queue do |payload|
-        result = MultiJson.load(payload)
+        result = Sensu::JSON.load(payload)
         expect(result[:client]).to eq("i-424242")
-        expect(result[:check][:name]).to eq("deregister")
+        expect(result[:check][:name]).to eq("deregistration")
         expect(result[:check][:status]).to eq(1)
         expect(result[:check][:handler]).to eq("DEREGISTER_HANDLER")
         async_done
       end
       timer(0.5) do
-        @client.setup_transport
-        @client.send_deregister_event
+        @client.setup_transport do
+          @client.send_deregister_event
+        end
       end
     end
   end

--- a/spec/config.json
+++ b/spec/config.json
@@ -166,7 +166,9 @@
       }
     },
     "deregister": true,
-    "deregister_handler": "DEREGISTER_HANDLER",
+    "deregistration": {
+      "handler": "DEREGISTER_HANDLER"
+    },
     "version": "TOBEREPLACED",
     "nested": {
       "attribute": true

--- a/spec/config.json
+++ b/spec/config.json
@@ -165,6 +165,8 @@
         "warning": 10
       }
     },
+    "deregister": true,
+    "deregister_handler": "DEREGISTER_HANDLER",
     "version": "TOBEREPLACED",
     "nested": {
       "attribute": true


### PR DESCRIPTION
Originally opened as #1309, now retargeted to `release/0.25` branch.

Currently client deregistration is implemented as an optional behavior in the [sensu-build SysV init scripts ](https://github.com/sensu/sensu-build/blob/3f148415bcd195692bd5d17147c6f19a9afcc060/sensu_configs/init.d/sensu-service#L200-L204), using some bash-isms to drop event JSON on the local client socket. This existing implementation is therefore only usable under certain platform configurations, and seems to be prone to some timing issues which can cause [strange behavior](https://github.com/sensu-plugins/sensu-plugins-sensu/issues/3). The changes in this PR build on @zbindliff's changes in #1191 to implement deregistration directly in the Sensu client process.

Similar [client registration events](https://sensuapp.org/docs/0.23/reference/clients.html#registration-events), client deregistration events may now be generated every time the Sensu client process is stopped gracefully. Client deregistration events are disabled by default, but can be enabled by setting `"client": { "deregister": true }` in the client's configuration.

Supersedes #1309. Closes #1191. Closes #1305. Closes https://github.com/sensu/sensu-build/issues/162.
