### PR TITLE
Fix server resume when transport not initialized

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -1106,15 +1106,24 @@ module Sensu
       # Resume the Sensu server process if it is currently or will
       # soon be paused. The `retry_until_true` helper method is used
       # to determine if the process is paused and if the Redis and
-      # transport connections are connected. If the conditions are
-      # met, `bootstrap()` will be called and true is returned to stop
-      # `retry_until_true`.
+      # transport connections are initiated and connected. If the
+      # conditions are met, `bootstrap()` will be called and true is
+      # returned to stop `retry_until_true`. If the transport has not
+      # yet been initiated, true is is returned, without calling
+      # bootstrap, as we expect bootstrap will be called after the
+      # transport initializes.
       def resume
         retry_until_true(1) do
           if @state == :paused
-            if @redis.connected? && @transport.connected?
-              bootstrap
-              true
+            if @redis.connected?
+              if @transport
+                if @transport.connected?
+                  bootstrap
+                  true
+                end
+              else
+                true
+              end
             end
           end
         end


### PR DESCRIPTION
Fixes:

```
{"timestamp":"2016-06-07T13:10:00.038913-0700","level":"debug","message":"connecting to redis","settings":null}
{"timestamp":"2016-06-07T13:10:00.039257-0700","level":"debug","message":"connecting to transport","name":"rabbitmq","settings":null}
{"timestamp":"2016-06-07T13:10:03.499383-0700","level":"warn","message":"reconnecting to redis"}
{"timestamp":"2016-06-07T13:10:03.499521-0700","level":"warn","message":"unsubscribing from keepalive and result queues"}
{"timestamp":"2016-06-07T13:10:03.499555-0700","level":"debug","message":"not currently the leader"}
{"timestamp":"2016-06-07T13:10:13.504252-0700","level":"info","message":"reconnected to redis"}
{"timestamp":"2016-06-07T13:10:14.506094-0700","level":"warn","message":"reconnecting to redis"}
/home/portertech/projects/sensu/sensu/lib/sensu/server/process.rb:1115:in `block in resume': undefined method `connected?' for nil:Nil
Class (NoMethodError)
        from /home/portertech/projects/sensu/sensu/lib/sensu/utilities.rb:20:in `block in retry_until_true'
        from /home/portertech/.gem/ruby/2.3.0/gems/eventmachine-1.2.0.1/lib/eventmachine.rb:194:in `run_machine'
        from /home/portertech/.gem/ruby/2.3.0/gems/eventmachine-1.2.0.1/lib/eventmachine.rb:194:in `run'
        from /home/portertech/projects/sensu/sensu/lib/sensu/server/process.rb:31:in `run'
        from ./exe/sensu-server:10:in `<main>'
```