### PR TITLE
Perform substitution on a clone of the check object

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -141,11 +141,14 @@ module Sensu
         @logger.debug("attempting to execute check command", :check => check)
         unless @checks_in_progress.include?(check[:name])
           @checks_in_progress << check[:name]
-          check, unmatched_tokens = object_substitute_tokens(check)
+          ## Marshal.load(Marshal.dump()) does a deep duplication of the check.
+          ## We still want to respond with the unstittued vesion of the command to store in
+          ## redis, that way we respect the `redact`
+          sub_check, unmatched_tokens = object_substitute_tokens(Marshal.load(Marshal.dump(check)))
           if unmatched_tokens.empty?
             started = Time.now.to_f
             check[:executed] = started.to_i
-            Spawn.process(check[:command], :timeout => check[:timeout]) do |output, status|
+            Spawn.process(sub_check[:command], :timeout => sub_check[:timeout]) do |output, status|
               check[:duration] = ("%.3f" % (Time.now.to_f - started)).to_f
               check[:output] = output
               check[:status] = status


### PR DESCRIPTION
Hope to fix issue laid out here: https://github.com/sensu/sensu/issues/1333

Because the substitution is done on the `check` object itself the command gets overwritten with the literal command that is ran.  This is then stored on redis and presented in Uchiwa. This is bad news for people that pass aws tokens or db passwords via the command line.  

I try to maintain same functionality that @UnitedMarsupials was aiming for while keeping it so that the un-substittued command and check is relayed up to the sensu-server. 