### PR TITLE
Use redis & transport callbacks with API

### DIFF
--- a/lib/sensu/api/process.rb
+++ b/lib/sensu/api/process.rb
@@ -15,10 +15,22 @@ module Sensu
       def self.run(options={})
         api = self.new(options)
         EM::run do
-          api.setup_redis
-          api.setup_transport
           api.start
           api.setup_signal_traps
+        end
+      end
+
+      # Setup connections to redis and transport
+      #
+      # @yield [Object] a callback/block to be called after redis and
+      #   transport connections have been established.
+      def setup_connections
+        setup_redis do |redis|
+          @redis = redis
+          setup_transport do |transport|
+            @transport = transport
+            yield if block_given?
+          end
         end
       end
 
@@ -43,11 +55,13 @@ module Sensu
       # Start the Sensu API HTTP server. This method sets the service
       # state to `:running`.
       def start
-        api = @settings[:api] || {}
-        bind = api[:bind] || "0.0.0.0"
-        port = api[:port] || 4567
-        start_http_server(bind, port)
-        super
+        setup_connections do
+          api = @settings[:api] || {}
+          bind = api[:bind] || "0.0.0.0"
+          port = api[:port] || 4567
+          start_http_server(bind, port)
+          super
+        end
       end
 
       # Stop the Sensu API process. This method stops the HTTP server,


### PR DESCRIPTION
Both `@redis` and `@transport` aren't guaranteed to be set by the time the API HTTP server starts serving requests. This PR implements the use of the `setup_redis` and `setup_transport` callbacks to ensure the connections are established.