### PR TITLE
Add http support to the client socket interface

### DIFF
--- a/lib/sensu/client/socket.rb
+++ b/lib/sensu/client/socket.rb
@@ -53,6 +53,22 @@ module Sensu
     # +WATCHDOG_DELAY+ (default is 500 msec) since the most recent chunk
     # of data was received, the agent will give up on the sender, and
     # instead respond +"invalid"+ and close the connection.
+    #
+    # == HTTP Protocol ==
+    #
+    # This is naturally implemented on top of the TCP protocol and
+    # requires sending an appropiate HTTP request. All requests
+    # will be responded with an appropiate HTTP response code and
+    # json body with a 'response' member typically set to 'ok' but
+    # that depends on the URL requested and whether the operation
+    # requested was successful or not.
+    # The following urls are available:
+    # /ping
+    #   This endpoint will simply return a 200 OK with a pong response
+    # /check
+    #   This endpoint must receive an application/json body with the
+    #   check information.
+    # Requesting an invalid URL returns 404, as it should be expected.
     class Socket < EM::Connection
       class DataError < StandardError; end
 

--- a/lib/sensu/client/socket.rb
+++ b/lib/sensu/client/socket.rb
@@ -301,9 +301,12 @@ module Sensu
       # @param [Int] code to use in the HTTP response
       # @param [String] message to use in the HTTP response
       def http_respond(response, code, message)
-        response_data = {
-          :response => response
-        }.to_json
+        response_data = case response
+                          when Hash then response.to_json
+                          when String then {
+                            :response => response
+                          }.to_json
+                        end
         http_response = [
           "HTTP/1.1 #{code} #{message}",
           "Content-Type: application/json",
@@ -326,6 +329,9 @@ module Sensu
         if url == '/ping'
           @logger.debug("http received ping")
           http_respond("pong", 200, "Pong!")
+        elsif url == '/settings'
+          @logger.debug("settings request", @settings.to_hash)
+          http_respond(@settings.to_hash, 200, "OK")
         elsif url == '/check'
           if headers['CONTENT-TYPE'].include? 'json'
             begin


### PR DESCRIPTION
This is definitely not finished. I am looking for comments on whether you even want this functionality and if the implementation is going in the right direction or what to change, etc. Particularly be warned this is the first time I write more than a couple of lines of Ruby, so may be I am missing proper idioms etc; I'd appreciate feedback there too.

This PR started after our discussion on issue #1235 . Instead of adding a little dummy header with the length I decided it'd make more sense to simply use bare bones HTTP. This opens up also the opportunity to accept more commands other than "ping", such as "stats" perhaps for introspection. In general, it just felt easier to do HTTP that come up with my own header/value spec to specify the json length upfront, etc;

The old-style raw check notifications and ping command are still supported.

Finally, the HTTP_PARSER_AVAILABLE global was an easy way for me to introduce this on some systems, but I'd like your opinion on whether this should be configurable or if it's acceptable to make http-parser a fixed dependency.

Thanks!
