### PR TITLE
Fix API /results when the last client in the registry has no checks

### DIFF
--- a/lib/sensu/api/routes/results.rb
+++ b/lib/sensu/api/routes/results.rb
@@ -46,7 +46,9 @@ module Sensu
                       end
                     end
                   elsif client_index == clients.length - 1
-                    respond
+                    @redis.ping do
+                      respond
+                    end
                   end
                 end
               end

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -9,7 +9,7 @@ gem "sensu-extension", "1.5.0"
 gem "sensu-extensions", "1.5.0"
 gem "sensu-transport", "6.0.0"
 gem "sensu-spawn", "2.2.0"
-gem "sensu-redis", "1.4.0"
+gem "sensu-redis", "1.5.0"
 
 require "time"
 require "uri"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sensu-extensions", "1.5.0"
   s.add_dependency "sensu-transport", "6.0.0"
   s.add_dependency "sensu-spawn", "2.2.0"
-  s.add_dependency "sensu-redis", "1.4.0"
+  s.add_dependency "sensu-redis", "1.5.0"
   s.add_dependency "em-http-server", "0.1.8"
 
   s.add_development_dependency "rake", "10.5.0"


### PR DESCRIPTION
This pull request fixes https://github.com/sensu/sensu/issues/1356, using a Redis PING call to serialize the HTTP response, ensuring the response content includes all of the results.

I believe that `/results` is the only route that requires a change like this.