### PR TITLE
Do not schedule standalone checks w/o an interval

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -318,16 +318,16 @@ module Sensu
 
       # Setup standalone check executions, scheduling standard check
       # definition and check extension executions. Check definitions
-      # and extensions with `:standalone` set to `true` and have an
-      # `:interval` will be scheduled by the Sensu client for
-      # execution.
+      # and extensions with `:standalone` set to `true`, have a
+      # integer `:interval`, and do not have `:publish` set to `false`
+      # will be scheduled by the Sensu client for execution.
       def setup_standalone
         @logger.debug("scheduling standalone checks")
         standard_checks = @settings.checks.select do |check|
-          check[:standalone] && check[:interval].is_a?(Integer)
+          check[:standalone] && check[:interval].is_a?(Integer) && check[:publish] != false
         end
         extension_checks = @extensions.checks.select do |check|
-          check[:standalone] && check[:interval].is_a?(Integer)
+          check[:standalone] && check[:interval].is_a?(Integer) && check[:publish] != false
         end
         schedule_checks(standard_checks + extension_checks)
       end

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -323,7 +323,7 @@ module Sensu
       def setup_standalone
         @logger.debug("scheduling standalone checks")
         standard_checks = @settings.checks.select do |check|
-          check[:standalone]
+          check[:standalone] && check[:interval].is_a?(Integer)
         end
         extension_checks = @extensions.checks.select do |check|
           check[:standalone] && check[:interval].is_a?(Integer)

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -318,8 +318,9 @@ module Sensu
 
       # Setup standalone check executions, scheduling standard check
       # definition and check extension executions. Check definitions
-      # and extensions with `:standalone` set to `true` will be
-      # scheduled by the Sensu client for execution.
+      # and extensions with `:standalone` set to `true` and have an
+      # `:interval` will be scheduled by the Sensu client for
+      # execution.
       def setup_standalone
         @logger.debug("scheduling standalone checks")
         standard_checks = @settings.checks.select do |check|


### PR DESCRIPTION
This pull requests brings the Sensu client check execution scheduler in-line with the behaviour of the Sensu server check request scheduler. The Sensu client will no longer attempt to schedule the execution of standalone checks if the definition has `"publish": false` and/or doesn't have a `"interval"`.

Closes: https://github.com/sensu/sensu/issues/1286

This is an alternative to https://github.com/sensu/sensu/pull/1287