### PR TITLE
Client Metrics Caching

### DIFF
--- a/lib/sensu/client/socket.rb
+++ b/lib/sensu/client/socket.rb
@@ -53,6 +53,22 @@ module Sensu
     # +WATCHDOG_DELAY+ (default is 500 msec) since the most recent chunk
     # of data was received, the agent will give up on the sender, and
     # instead respond +"invalid"+ and close the connection.
+    #
+    # == HTTP Protocol ==
+    #
+    # This is naturally implemented on top of the TCP protocol and
+    # requires sending an appropiate HTTP request. All requests
+    # will be responded with an appropiate HTTP response code and
+    # json body with a 'response' member typically set to 'ok' but
+    # that depends on the URL requested and whether the operation
+    # requested was successful or not.
+    # The following urls are available:
+    # /ping
+    #   This endpoint will simply return a 200 OK with a pong response
+    # /check
+    #   This endpoint must receive an application/json body with the
+    #   check information.
+    # Requesting an invalid URL returns 404, as it should be expected.
     class Socket < EM::Connection
       class DataError < StandardError; end
 

--- a/lib/sensu/client/socket.rb
+++ b/lib/sensu/client/socket.rb
@@ -301,9 +301,12 @@ module Sensu
       # @param [Int] code to use in the HTTP response
       # @param [String] message to use in the HTTP response
       def http_respond(response, code, message)
-        response_data = {
-          :response => response
-        }.to_json
+        response_data = case response
+                          when Hash then response.to_json
+                          when String then {
+                            :response => response
+                          }.to_json
+                        end
         http_response = [
           "HTTP/1.1 #{code} #{message}",
           "Content-Type: application/json",
@@ -326,6 +329,9 @@ module Sensu
         if url == '/ping'
           @logger.debug("http received ping")
           http_respond("pong", 200, "Pong!")
+        elsif url == '/settings'
+          @logger.debug("settings request", @settings.to_hash)
+          http_respond(@settings.to_hash, 200, "OK")
         elsif url == '/check'
           if headers['CONTENT-TYPE'].include? 'json'
             begin

--- a/lib/sensu/client/store.rb
+++ b/lib/sensu/client/store.rb
@@ -1,0 +1,112 @@
+require "sqlite3"
+
+module Sensu
+  module Client
+    # Simple data store for the sensu client
+    #
+    # Although using something like Moneta seemed appealing, it does
+    # not support iteration. I did not want to use redis either to avoid
+    # requiring a separate process. There's then rlite which seems quite
+    # interesting but immature, little docs, and not nearly as battle-tested
+    # as sqlite. Finally, we have vedis, but little support for ruby
+    # apparently, could not find usable bindings and in general it seems
+    # our simple needs are achieved with sqlite.
+    # May be at some point we should test the reliability of rlite and
+    # use that if suitable, as it does seems nice.
+    class Store
+      def initialize(collection, logger)
+        @db = SQLite3::Database.new('sensu-client.db')
+        @collection = collection
+        @logger = logger
+        # We could use BLOB, but in sqlite everything is stored as text
+        # anyways and using TEXT helps with debugging via sqlite cmdline
+        # We use an id just because we can and helps sorting in order of
+        # insertion and sqlite uses row ids internally anyways so it does
+        # not need extra space.
+        collection_sql = %{
+          CREATE TABLE IF NOT EXISTS #{collection}(id INTEGER PRIMARY KEY AUTOINCREMENT, key TEXT UNIQUE NOT NULL, value TEXT)
+        }
+        begin
+          @db.execute(collection_sql)
+          return true
+        rescue SQLite3::Exception
+          @logger.error("Failed to initialize collection #{@collection}: #{$!}")
+          return false
+        end
+      end
+
+      def set(key, value)
+        begin
+          st = @db.prepare("REPLACE INTO #{@collection} (key, value) VALUES(?, ?)")
+          st.execute(key, value).close
+          return true
+        rescue SQLite3::Exception
+          @logger.error("Failed to set key #{key} to value #{value}: #{$!}")
+          return false
+        end
+      end
+
+      def get(key)
+        begin
+          rs = @db.prepare("SELECT value FROM #{@collection} WHERE key = ?").execute(key)
+          r = rs.next
+          rs.close
+          if r
+            return r[0]
+          end
+        rescue SQLite3::Exception
+          @logger.error("Failed to get key #{key}: #{$!}")
+        end
+        return nil
+      end
+
+      def each
+        return enum_for(:each) unless block_given?
+        begin
+          st = @db.prepare("SELECT key, value FROM #{@collection} ORDER BY id ASC")
+          st.execute! do |row|
+            yield row
+          end
+          st.close
+        rescue SQLite3::Exception
+          @logger.error("Failed to iterate over collection #{@collection}: #{$!}")
+        end
+      end
+
+      def clear(limit_key=nil)
+        begin
+          query = "DELETE FROM #{@collection}"
+          if limit_key.nil?
+            @db.prepare(query).execute().close
+          else
+            query += " WHERE id <= (SELECT id FROM #{@collection} WHERE key = ?)"
+            @db.prepare(query).execute(limit_key).close
+          end
+        rescue SQLite3::Exception
+          @logger.error("Failed to clear collection #{@collection}: #{$!}")
+        end
+      end
+
+      def length
+        begin
+          return @db.get_first_value("SELECT COUNT(*) FROM #{@collection}")
+        rescue SQLite3::Exception
+          @logger.error("Failed to get key #{key}: #{$!}")
+        end
+      end
+
+      def close(drop=false)
+        begin
+          if drop
+            @db.execute("DROP TABLE #{@collection}")
+          end
+          @db.close
+          return true
+        rescue SQLite3::Exception
+          @logger.error("Failed to close db: #{$!}")
+          return false
+        end
+      end
+    end
+  end
+end

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -652,6 +652,8 @@ module Sensu
       def publish_check_request(check)
         payload = {
           :name => check[:name],
+          :interval => check[:interval],
+          :type => check[:type],
           :issued => Time.now.to_i
         }
         payload[:command] = check[:command] if check.has_key?(:command)


### PR DESCRIPTION
This PR introduces metrics caching. In the event of losing network connection, the client will move to use standalone metric checks and cache the results locally. Due to our requirements, we cannot simply put all the checks in the node, in the future we may be able, but for now I am caching the check requests as well to know what to self-schedule when the network connection is lost. I have a TODO to invalidate that cache every N minutes for example so if we stop receiving a check request it'll be removed from the cache.

This PR depends on changes to the rabbitmq transport to enable message acknowledgements to detect when a keepalive was not acknowledged by the server and declare the connection down faster. I will be doing a separate PR for that in sensu/transport, but I am doing changes in other areas that I wanted to first get some feedback on the whole idea of caching and the direction we're taking.

There's a couple of commits related to a different PR here, so ignore changes in socket.rb, is just that our internal branch has multiple changes we've done and I did not have the chance yet to separate this code in a different branch. I just want initial feedback for this feature.

The use of sqlite might be controversial, but I wanted to keep things simple, avoiding a separate process (e.g relying on redis). I think you guys may have plans to require redis on the client at some point anyways? if that happens should be relatively easy to move to another db backend.

There's things that I plan to make configurable like the max amount of metrics to cache (currently unlimited) and the sync rate (as to not overwhelm the server if hundreds of nodes go offline and back online at the same time due to datacenter issues).
