### PR TITLE
Add cron to sensu

### DIFF
--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sensu-spawn", "2.2.0"
   s.add_dependency "sensu-redis", "1.4.0"
   s.add_dependency "em-http-server", "0.1.8"
+  s.add_dependency "parse-cron", "0.1.4"
 
   s.add_development_dependency "rake", "10.5.0"
   s.add_development_dependency "rspec", "~> 3.0.0"

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -662,4 +662,15 @@ describe "Sensu::Server::Process" do
       end
     end
   end
+
+  it "can schedule checks using cron" do
+    async_wrapper do
+      check = check_template
+      check[:cron] = "* * * * *"
+      create_check_request = @server.get_check_request_block(check)
+      @server.schedule_cron(check, &create_check_request)
+      expect(@server.instance_variable_get(:@timers).length == 1)
+      async_done
+    end
+  end
 end


### PR DESCRIPTION
Hi folks,

This is a relatively simple add of the "cron" attribute; it enables cron expressions that effectively override the "interval" attribute on a check. I've found this very useful for several of our batch checks that need to run at very specific times in house. Unless I'm missing a way to do this using interval.

I'd be happy to tidy this up as needed (for example, "interval" is still required on a check even if you specify "cron"); or simply request that this be added as a feature in a future release.

Thanks!
