### PR TITLE
Built-in Silencing

### DIFF
--- a/lib/sensu/api/http_handler.rb
+++ b/lib/sensu/api/http_handler.rb
@@ -95,8 +95,8 @@ module Sensu
           data = Sensu::JSON.load(@http_content)
           valid = data.is_a?(Hash) && rules.all? do |key, rule|
             value = data[key]
-            (value.is_a?(rule[:type]) || (rule[:nil_ok] && value.nil?)) &&
-              (value.nil? || rule[:regex].nil?) ||
+            (Array(rule[:type]).any? {|type| value.is_a?(type)} ||
+              (rule[:nil_ok] && value.nil?)) && (value.nil? || rule[:regex].nil?) ||
               (rule[:regex] && (value =~ rule[:regex]) == 0)
           end
           if valid

--- a/lib/sensu/api/routes.rb
+++ b/lib/sensu/api/routes.rb
@@ -8,6 +8,7 @@ require "sensu/api/routes/resolve"
 require "sensu/api/routes/aggregates"
 require "sensu/api/routes/stashes"
 require "sensu/api/routes/results"
+require "sensu/api/routes/silenced"
 
 module Sensu
   module API
@@ -22,6 +23,7 @@ module Sensu
       include Aggregates
       include Stashes
       include Results
+      include Silenced
 
       GET_METHOD = "GET".freeze
       HEAD_METHOD = "HEAD".freeze
@@ -49,7 +51,10 @@ module Sensu
         [STASH_URI, :get_stash],
         [RESULTS_URI, :get_results],
         [RESULTS_CLIENT_URI, :get_results_client],
-        [RESULT_URI, :get_result]
+        [RESULT_URI, :get_result],
+        [SILENCED_URI, :get_silenced],
+        [SILENCED_SUBSCRIPTION_URI, :get_silenced_subscription],
+        [SILENCED_CHECK_URI, :get_silenced_check]
       ]
 
       ROUTES = {
@@ -61,7 +66,9 @@ module Sensu
           [RESOLVE_URI, :post_resolve],
           [STASHES_URI, :post_stashes],
           [STASH_URI, :post_stash],
-          [RESULTS_URI, :post_results]
+          [RESULTS_URI, :post_results],
+          [SILENCED_URI, :post_silenced],
+          [SILENCED_CLEAR_URI, :post_silenced_clear]
         ],
         DELETE_METHOD => [
           [CLIENT_URI, :delete_client],

--- a/lib/sensu/api/routes/silenced.rb
+++ b/lib/sensu/api/routes/silenced.rb
@@ -14,7 +14,8 @@ module Sensu
             :check => {:type => String, :nil_ok => true, :regex => /\A[\w\.-]+\z/},
             :expire => {:type => Integer, :nil_ok => true},
             :reason => {:type => String, :nil_ok => true},
-            :creator => {:type => String, :nil_ok => true}
+            :creator => {:type => String, :nil_ok => true},
+            :expire_on_resolve => {:type => [TrueClass, FalseClass], :nil_ok => true}
           }
           read_data(rules) do |data|
             if data[:subscription] || data[:check]

--- a/lib/sensu/api/routes/silenced.rb
+++ b/lib/sensu/api/routes/silenced.rb
@@ -20,7 +20,7 @@ module Sensu
             if data[:subscription] || data[:check]
               subscription = data.fetch(:subscription, "*")
               check = data.fetch(:check, "*")
-              silenced_key = "#{subscription}:#{check}"
+              silenced_key = "silenced:#{subscription}:#{check}"
               silenced_info = {
                 :subscription => data[:subscription],
                 :check => data[:check],
@@ -28,7 +28,6 @@ module Sensu
                 :reason => data[:reason],
                 :creator => data[:creator]
               }
-              puts silenced_info.inspect
               @redis.set(silenced_key, Sensu::JSON.dump(silenced_info)) do
                 @redis.sadd("silenced", silenced_key) do
                   if data[:expire]
@@ -73,7 +72,7 @@ module Sensu
           @response_content = []
           @redis.smembers("silenced") do |silenced_keys|
             silenced_keys.select! do |key|
-              key =~ /^#{subscription}:/
+              key =~ /^silenced:#{subscription}:/
             end
             unless silenced_keys.empty?
               @redis.mget(*silenced_keys) do |silenced|
@@ -98,7 +97,7 @@ module Sensu
           @response_content = []
           @redis.smembers("silenced") do |silenced_keys|
             silenced_keys.select! do |key|
-              key =~ /^.*:#{check_name}$/
+              key =~ /.*:#{check_name}$/
             end
             unless silenced_keys.empty?
               @redis.mget(*silenced_keys) do |silenced|
@@ -127,7 +126,7 @@ module Sensu
             if data[:subscription] || data[:check]
               subscription = data.fetch(:subscription, "*")
               check = data.fetch(:check, "*")
-              silenced_key = "#{subscription}:#{check}"
+              silenced_key = "silenced:#{subscription}:#{check}"
               @redis.srem("silenced", silenced_key) do
                 @redis.del(silenced_key) do
                   no_content!

--- a/lib/sensu/api/routes/silenced.rb
+++ b/lib/sensu/api/routes/silenced.rb
@@ -1,0 +1,144 @@
+module Sensu
+  module API
+    module Routes
+      module Silenced
+        SILENCED_URI = /^\/silenced$/
+        SILENCED_SUBSCRIPTION_URI = /^\/silenced\/subscriptions\/([\w\.-]+)$/
+        SILENCED_CHECK_URI = /^\/silenced\/checks\/([\w\.-]+)$/
+        SILENCED_CLEAR_URI = /^\/silenced\/clear$/
+
+        # POST /silenced
+        def post_silenced
+          rules = {
+            :subscription => {:type => String, :nil_ok => true},
+            :check => {:type => String, :nil_ok => true, :regex => /\A[\w\.-]+\z/},
+            :expire => {:type => Integer, :nil_ok => true},
+            :reason => {:type => String, :nil_ok => true},
+            :creator => {:type => String, :nil_ok => true}
+          }
+          read_data(rules) do |data|
+            if data[:subscription] || data[:check]
+              subscription = data.fetch(:subscription, "*")
+              check = data.fetch(:check, "*")
+              silenced_key = "#{subscription}:#{check}"
+              silenced_info = {
+                :subscription => data[:subscription],
+                :check => data[:check],
+                :expire => data[:expire],
+                :reason => data[:reason],
+                :creator => data[:creator]
+              }
+              puts silenced_info.inspect
+              @redis.set(silenced_key, Sensu::JSON.dump(silenced_info)) do
+                @redis.sadd("silenced", silenced_key) do
+                  if data[:expire]
+                    @redis.expire(silenced_key, data[:expire]) do
+                      created!
+                    end
+                  else
+                    created!
+                  end
+                end
+              end
+            else
+              bad_request!
+            end
+          end
+        end
+
+        # GET /silenced
+        def get_silenced
+          @response_content = []
+          @redis.smembers("silenced") do |silenced_keys|
+            unless silenced_keys.empty?
+              @redis.mget(*silenced_keys) do |silenced|
+                silenced_keys.each_with_index do |silenced_key, silenced_index|
+                  if silenced[silenced_index]
+                    @response_content << Sensu::JSON.load(silenced[silenced_index])
+                  else
+                    @redis.srem("silenced", silenced_key)
+                  end
+                end
+                respond
+              end
+            else
+              respond
+            end
+          end
+        end
+
+        # GET /silenced/subscriptions/:subscription
+        def get_silenced_subscription
+          subscription = parse_uri(SILENCED_SUBSCRIPTION_URI).first
+          @response_content = []
+          @redis.smembers("silenced") do |silenced_keys|
+            silenced_keys.select! do |key|
+              key =~ /^#{subscription}:/
+            end
+            unless silenced_keys.empty?
+              @redis.mget(*silenced_keys) do |silenced|
+                silenced_keys.each_with_index do |silenced_key, silenced_index|
+                  if silenced[silenced_index]
+                    @response_content << Sensu::JSON.load(silenced[silenced_index])
+                  else
+                    @redis.srem("silenced", silenced_key)
+                  end
+                end
+                respond
+              end
+            else
+              respond
+            end
+          end
+        end
+
+        # GET /silenced/checks/:check
+        def get_silenced_check
+          check_name = parse_uri(SILENCED_CHECK_URI).first
+          @response_content = []
+          @redis.smembers("silenced") do |silenced_keys|
+            silenced_keys.select! do |key|
+              key =~ /^.*:#{check_name}$/
+            end
+            unless silenced_keys.empty?
+              @redis.mget(*silenced_keys) do |silenced|
+                silenced_keys.each_with_index do |silenced_key, silenced_index|
+                  if silenced[silenced_index]
+                    @response_content << Sensu::JSON.load(silenced[silenced_index])
+                  else
+                    @redis.srem("silenced", silenced_key)
+                  end
+                end
+                respond
+              end
+            else
+              respond
+            end
+          end
+        end
+
+        # POST /silenced/clear
+        def post_silenced_clear
+          rules = {
+            :subscription => {:type => String, :nil_ok => true},
+            :check => {:type => String, :nil_ok => true, :regex => /\A[\w\.-]+\z/}
+          }
+          read_data(rules) do |data|
+            if data[:subscription] || data[:check]
+              subscription = data.fetch(:subscription, "*")
+              check = data.fetch(:check, "*")
+              silenced_key = "#{subscription}:#{check}"
+              @redis.srem("silenced", silenced_key) do
+                @redis.del(silenced_key) do
+                  no_content!
+                end
+              end
+            else
+              bad_request!
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -113,6 +113,16 @@ module Sensu
         end
       end
 
+      # Determine if an event handler is silenced.
+      #
+      # @param handler [Hash] definition.
+      # @param event [Hash]
+      # @return [TrueClass, FalseClass]
+      def handler_silenced?(handler, event)
+        event[:silenced] && !handler[:handle_silenced] &&
+          !(event[:check][:type] == "metric" && event[:check][:status] == 0)
+      end
+
       # Determine if handling is disabled for an event. Check
       # definitions can disable event handling with an attribute,
       # `:handle`, by setting it to `false`.
@@ -340,6 +350,8 @@ module Sensu
           "handler does not handle action"
         when !handle_severity?(handler, event)
           "handler does not handle event severity"
+        when handler_silenced?(handler, event)
+          "handler is silenced"
         when handler_subdued?(handler, event)
           "handler is subdued"
         end

--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -119,8 +119,7 @@ module Sensu
       # @param event [Hash]
       # @return [TrueClass, FalseClass]
       def handler_silenced?(handler, event)
-        event[:silenced] && !handler[:handle_silenced] &&
-          !(event[:check][:type] == "metric" && event[:check][:status] == 0)
+        event[:silenced] && !handler[:handle_silenced]
       end
 
       # Determine if handling is disabled for an event. Check

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -1169,4 +1169,278 @@ describe "Sensu::API::Process" do
       end
     end
   end
+
+  it "can create a silenced registry entry for a subscription" do
+    api_test do
+      options = {
+        :body => {
+          :subscription => "test"
+        }
+      }
+      api_request("/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(201)
+        redis.get("silenced:test:*") do |silenced_info_json|
+          silenced_info = Sensu::JSON.load(silenced_info_json)
+          expect(silenced_info[:subscription]).to eq("test")
+          expect(silenced_info[:check]).to be_nil
+          expect(silenced_info[:reason]).to be_nil
+          expect(silenced_info[:creator]).to be_nil
+          expect(silenced_info[:expire_on_resolve]).to eq(false)
+          async_done
+        end
+      end
+    end
+  end
+
+  it "can create a silenced registry entry for a check" do
+    api_test do
+      options = {
+        :body => {
+          :check => "test"
+        }
+      }
+      api_request("/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(201)
+        redis.get("silenced:*:test") do |silenced_info_json|
+          silenced_info = Sensu::JSON.load(silenced_info_json)
+          expect(silenced_info[:subscription]).to be_nil
+          expect(silenced_info[:check]).to eq("test")
+          expect(silenced_info[:reason]).to be_nil
+          expect(silenced_info[:creator]).to be_nil
+          expect(silenced_info[:expire_on_resolve]).to eq(false)
+          async_done
+        end
+      end
+    end
+  end
+
+  it "can create a silenced registry entry that expires" do
+    api_test do
+      options = {
+        :body => {
+          :subscription => "test",
+          :check => "test",
+          :expire => 3600,
+          :reason => "testing",
+          :creator => "rspec",
+          :expire_on_resolve => true
+        }
+      }
+      api_request("/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(201)
+        redis.get("silenced:test:test") do |silenced_info_json|
+          silenced_info = Sensu::JSON.load(silenced_info_json)
+          expect(silenced_info[:subscription]).to eq("test")
+          expect(silenced_info[:check]).to eq("test")
+          expect(silenced_info[:reason]).to eq("testing")
+          expect(silenced_info[:creator]).to eq("rspec")
+          expect(silenced_info[:expire_on_resolve]).to eq(true)
+          redis.ttl("silenced:test:test") do |ttl|
+            expect(ttl).to be_within(10).of(3600)
+            async_done
+          end
+        end
+      end
+    end
+  end
+
+  it "can not create a silenced registry entry when missing a subscription and/or check" do
+    api_test do
+      options = {
+        :body => {
+          :expire => 3600,
+          :reason => "testing",
+          :creator => "rspec",
+          :expire_on_resolve => true
+        }
+      }
+      api_request("/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        async_done
+      end
+    end
+  end
+
+  it "can not create a silenced registry entry with an invalid subscription" do
+    api_test do
+      options = {
+        :body => {
+          :subscription => 1,
+          :check => "test"
+        }
+      }
+      api_request("/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        async_done
+      end
+    end
+  end
+
+  it "can not create a silenced registry entry with an invalid check" do
+    api_test do
+      options = {
+        :body => {
+          :subscription => "test",
+          :check => 1
+        }
+      }
+      api_request("/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        async_done
+      end
+    end
+  end
+
+  it "can not create a silenced registry entry with an invalid expire" do
+    api_test do
+      options = {
+        :body => {
+          :subscription => "test",
+          :check => "test",
+          :expire => "3600"
+        }
+      }
+      api_request("/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        async_done
+      end
+    end
+  end
+
+  it "can not create a silenced registry entry with an invalid reason" do
+    api_test do
+      options = {
+        :body => {
+          :subscription => "test",
+          :check => "test",
+          :reason => 1
+        }
+      }
+      api_request("/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        async_done
+      end
+    end
+  end
+
+  it "can not create a silenced registry entry with an invalid creator" do
+    api_test do
+      options = {
+        :body => {
+          :subscription => "test",
+          :check => "test",
+          :creator => 1
+        }
+      }
+      api_request("/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        async_done
+      end
+    end
+  end
+
+  it "can not create a silenced registry entry with an invalid expire_on_resolve" do
+    api_test do
+      options = {
+        :body => {
+          :subscription => "test",
+          :check => "test",
+          :expire_on_resolve => "true"
+        }
+      }
+      api_request("/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        async_done
+      end
+    end
+  end
+
+  it "can provide the silenced registry" do
+    api_test do
+      options = {
+        :body => {
+          :subscription => "test",
+          :check => "test",
+          :expire => 3600
+        }
+      }
+      api_request("/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(201)
+        api_request("/silenced") do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Array)
+          expect(body.length).to eq(1)
+          silenced_info = body.first
+          expect(silenced_info).to be_kind_of(Hash)
+          expect(silenced_info[:subscription]).to eq("test")
+          expect(silenced_info[:check]).to eq("test")
+          expect(silenced_info[:expire]).to be_within(10).of(3600)
+          api_request("/silenced/subscriptions/test") do |http, body|
+            expect(http.response_header.status).to eq(200)
+            expect(body).to be_kind_of(Array)
+            expect(body.length).to eq(1)
+            silenced_info = body.first
+            expect(silenced_info).to be_kind_of(Hash)
+            expect(silenced_info[:subscription]).to eq("test")
+            expect(silenced_info[:expire]).to be_within(10).of(3600)
+            api_request("/silenced/subscriptions/nonexistent") do |http, body|
+              expect(http.response_header.status).to eq(200)
+              expect(body).to be_kind_of(Array)
+              expect(body).to be_empty
+              api_request("/silenced/checks/test") do |http, body|
+                expect(http.response_header.status).to eq(200)
+                expect(body).to be_kind_of(Array)
+                expect(body.length).to eq(1)
+                silenced_info = body.first
+                expect(silenced_info).to be_kind_of(Hash)
+                expect(silenced_info[:check]).to eq("test")
+                expect(silenced_info[:expire]).to be_within(10).of(3600)
+                api_request("/silenced/checks/nonexistent") do |http, body|
+                  expect(http.response_header.status).to eq(200)
+                  expect(body).to be_kind_of(Array)
+                  expect(body).to be_empty
+                  async_done
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  it "can delete a silenced registry entry" do
+    api_test do
+      options = {
+        :body => {
+          :subscription => "test",
+          :check => "test"
+        }
+      }
+      api_request("/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(201)
+        api_request("/silenced") do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Array)
+          expect(body.length).to eq(1)
+          silenced_info = body.first
+          expect(silenced_info).to be_kind_of(Hash)
+          expect(silenced_info[:subscription]).to eq("test")
+          expect(silenced_info[:check]).to eq("test")
+          api_request("/silenced/clear", :post, options) do |http, body|
+            expect(http.response_header.status).to eq(204)
+            api_request("/silenced/clear", :post, options) do |http, body|
+              expect(http.response_header.status).to eq(404)
+              api_request("/silenced") do |http, body|
+                expect(http.response_header.status).to eq(200)
+                expect(body).to be_kind_of(Array)
+                expect(body).to be_empty
+                async_done
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -132,6 +132,8 @@ module Helpers
       :client => client,
       :check => check,
       :occurrences => 1,
+      :silenced => false,
+      :silenced_by => [],
       :action => :create
     }
   end

--- a/spec/server/filter_spec.rb
+++ b/spec/server/filter_spec.rb
@@ -101,6 +101,19 @@ describe "Sensu::Server::Filter" do
     expect(@server.check_request_subdued?(check)).to be(true)
   end
 
+  it "can determine if handler handles a silenced event" do
+    expect(@server.handler_silenced?(@handler, @event)).to be(false)
+    @event[:silenced] = true
+    expect(@server.handler_silenced?(@handler, @event)).to be(true)
+    @handler[:handle_silenced] = true
+    expect(@server.handler_silenced?(@handler, @event)).to be(false)
+    @handler[:handle_silenced] = false
+    expect(@server.handler_silenced?(@handler, @event)).to be(true)
+    @event[:check][:type] = "metric"
+    @event[:check][:status] = 0
+    expect(@server.handler_silenced?(@handler, @event)).to be(false)
+  end
+
   it "can determine if handling is disabled for an event" do
     expect(@server.handling_disabled?(@event)).to be(false)
     @event[:check][:handle] = false
@@ -218,6 +231,11 @@ describe "Sensu::Server::Filter" do
         raise "not filtered"
       end
       handler.delete(:severities)
+      @event[:silenced] = true
+      @server.filter_event(handler, @event) do
+        raise "not filtered"
+      end
+      @event[:silenced] = false
       handler[:subdue] = {
         :begin => (Time.now - 3600).strftime("%l:00 %p").strip,
         :end => (Time.now + 3600).strftime("%l:00 %p").strip

--- a/spec/server/filter_spec.rb
+++ b/spec/server/filter_spec.rb
@@ -109,9 +109,6 @@ describe "Sensu::Server::Filter" do
     expect(@server.handler_silenced?(@handler, @event)).to be(false)
     @handler[:handle_silenced] = false
     expect(@server.handler_silenced?(@handler, @event)).to be(true)
-    @event[:check][:type] = "metric"
-    @event[:check][:status] = 0
-    expect(@server.handler_silenced?(@handler, @event)).to be(false)
   end
 
   it "can determine if handling is disabled for an event" do


### PR DESCRIPTION
A implementation of https://github.com/sensu/sensu/issues/1328

Closes: https://github.com/sensu/sensu/issues/1328

Example event data with silencing attributes:

``` json
{
  "check": {
    "name": "check-http",
    "...": "..."
  },
  "client": {
    "name": "i-424242",
    "subscriptions": [
      "webserver",
      "staging"
    ],
    "...": "..."
  },
  "silenced": true,
  "silenced_by": [
    "*:check-http",
    "staging:*"
    "client:i-424242:*"
  ]
}
```