### PR TITLE
Ensure /health API returns 204 No Content for "OK" responses

### DIFF
--- a/lib/sensu/api/http_handler.rb
+++ b/lib/sensu/api/http_handler.rb
@@ -248,11 +248,11 @@ module Sensu
         respond
       end
 
-      # Respond to the HTTP request with a `204` (No Response)
+      # Respond to the HTTP request with a `204` (No Content)
       # response.
       def no_content!
         @response_status = 204
-        @response_status_string = "No Response"
+        @response_status_string = "No Content"
         respond
       end
 

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -64,6 +64,7 @@ describe "Sensu::API::Process" do
     api_test do
       api_request("/health?consumers=0&messages=1000") do |http, body|
         expect(http.response_header.status).to eq(204)
+        expect(http.response_header.http_reason).to eq('No Content')
         expect(body).to be_empty
         api_request("/health?consumers=1000") do |http, body|
           expect(http.response_header.status).to eq(412)

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -724,6 +724,7 @@ describe "Sensu::API::Process" do
     api_test do
       api_request("/stash/test/test", :delete) do |http, body|
         expect(http.response_header.status).to eq(204)
+        expect(http.response_header.http_reason).to eq('No Content')
         expect(body).to be_empty
         redis.exists("stash:test/test") do |exists|
           expect(exists).to be(false)
@@ -767,6 +768,7 @@ describe "Sensu::API::Process" do
         timer(1) do
           api_request("/aggregates/test", :delete) do |http, body|
             expect(http.response_header.status).to eq(204)
+            expect(http.response_header.http_reason).to eq('No Content')
             expect(body).to be_empty
             redis.sismember("aggregates", "test") do |exists|
               expect(exists).to be(false)
@@ -788,6 +790,7 @@ describe "Sensu::API::Process" do
         timer(1) do
           api_request("/aggregates/TEST", :delete) do |http, body|
             expect(http.response_header.status).to eq(204)
+            expect(http.response_header.http_reason).to eq('No Content')
             expect(body).to be_empty
             redis.sismember("aggregates", "TEST") do |exists|
               expect(exists).to be(false)
@@ -1155,6 +1158,7 @@ describe "Sensu::API::Process" do
     api_test do
       api_request("/results/i-424242/test", :delete) do |http, body|
         expect(http.response_header.status).to eq(204)
+        expect(http.response_header.http_reason).to eq('No Content')
         expect(body).to be_empty
         async_done
       end


### PR DESCRIPTION
As documented in #1405, the API is returning "204 No Response" instead of the
commonly accepted "204 No Content", which is also the documented behavior. This
change fixes the implementation and adds a test for the expected response
reason.

Closes #1405