### PR TITLE
Subdue 2.0

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.0.1"
 
 gem "sensu-json", "2.0.0"
 gem "sensu-logger", "1.2.0"
-gem "sensu-settings", "8.0.0"
+gem "sensu-settings", "9.1.0"
 gem "sensu-extension", "1.5.0"
 gem "sensu-extensions", "1.6.0"
 gem "sensu-transport", "6.0.0"

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -34,7 +34,7 @@ module Sensu
   module Daemon
     include Utilities
 
-    attr_reader :start_time
+    attr_reader :start_time, :settings
 
     # Initialize the Sensu process. Set the start time, initial
     # service state, double the maximum number of EventMachine timers,

--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -164,9 +164,9 @@ module Sensu
       #
       # @param filter [Hash] definition.
       # @return [TrueClass, FalseClass]
-      def in_filter_time_window?(filter)
+      def in_filter_time_windows?(filter)
         if filter[:when]
-          in_time_window?(filter[:when])
+          in_time_windows?(filter[:when])
         else
           true
         end
@@ -182,7 +182,7 @@ module Sensu
       #   event was filtered.
       def native_filter(filter_name, event)
         filter = @settings[:filters][filter_name]
-        if in_filter_time_window?(filter)
+        if in_filter_time_windows?(filter)
           matched = filter_attributes_match?(event, filter[:attributes])
           yield(filter[:negate] ? matched : !matched)
         else
@@ -200,7 +200,7 @@ module Sensu
       #   event was filtered.
       def extension_filter(filter_name, event)
         extension = @extensions[:filters][filter_name]
-        if in_filter_time_window?(extension.definition)
+        if in_filter_time_windows?(extension.definition)
           extension.safe_run(event) do |output, status|
             yield(status == 0)
           end

--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -5,114 +5,6 @@ module Sensu
     module Filter
       EVAL_PREFIX = "eval:".freeze
 
-      # Determine if a period of time (window) is subdued. The
-      # provided condition must have a `:begin` and `:end` time, eg.
-      # "11:30:00 PM", or `false` will be returned.
-      #
-      # @param condition [Hash]
-      # @option condition [String] :begin time.
-      # @option condition [String] :end time.
-      # @return [TrueClass, FalseClass]
-      def subdue_time?(condition)
-        if condition.has_key?(:begin) && condition.has_key?(:end)
-          begin_time = Time.parse(condition[:begin])
-          end_time = Time.parse(condition[:end])
-          if end_time < begin_time
-            if Time.now < end_time
-              begin_time = Time.parse("12:00:00 AM")
-            else
-              end_time = Time.parse("11:59:59 PM")
-            end
-          end
-          Time.now >= begin_time && Time.now <= end_time
-        else
-          false
-        end
-      end
-
-      # Determine if the current day is subdued. The provided
-      # condition must have a list of `:days`, or false will be
-      # returned.
-      #
-      # @param condition [Hash]
-      # @option condition [Array] :days of the week to subdue.
-      # @return [TrueClass, FalseClass]
-      def subdue_days?(condition)
-        if condition.has_key?(:days)
-          days = condition[:days].map(&:downcase)
-          days.include?(Time.now.strftime("%A").downcase)
-        else
-          false
-        end
-      end
-
-      # Determine if there is an exception a period of time (window)
-      # that is subdued. The provided condition must have an
-      # `:exception`, containing one or more `:begin` and `:end`
-      # times, eg. "11:30:00 PM", or `false` will be returned. If
-      # there are any exceptions to a subdued period of time, `true`
-      # will be returned.
-      #
-      # @param condition [Hash]
-      # @option condition [Hash] :exceptions array of `:begin` and
-      #   `:end` times.
-      # @return [TrueClass, FalseClass]
-      def subdue_exception?(condition)
-        if condition.has_key?(:exceptions)
-          condition[:exceptions].any? do |exception|
-            Time.now >= Time.parse(exception[:begin]) && Time.now <= Time.parse(exception[:end])
-          end
-        else
-          false
-        end
-      end
-
-      # Determine if an action is subdued and if there is an
-      # exception. This method makes use of `subdue_time?()`,
-      # `subdue_days?()`, and subdue_exception?().
-      #
-      # @param condition [Hash]
-      # @return [TrueClass, FalseClass]
-      def action_subdued?(condition)
-        subdued = subdue_time?(condition) || subdue_days?(condition)
-        subdued && !subdue_exception?(condition)
-      end
-
-      # Determine if an event handler is subdued, by conditions set in
-      # the check and/or the handler definition. If any of the
-      # conditions are true, without an exception, the handler is
-      # subdued.
-      #
-      # @param handler [Hash] definition.
-      # @param event [Hash] data possibly containing subdue
-      #   conditions.
-      # @return [TrueClass, FalseClass]
-      def handler_subdued?(handler, event)
-        subdued = []
-        if handler[:subdue]
-          subdued << action_subdued?(handler[:subdue])
-        end
-        check = event[:check]
-        if check[:subdue] && check[:subdue][:at] != "publisher"
-          subdued << action_subdued?(check[:subdue])
-        end
-        subdued.any?
-      end
-
-      # Determine if a check request is subdued, by conditions set in
-      # the check definition. If any of the conditions are true,
-      # without an exception, the check request is subdued.
-      #
-      # @param check [Hash] definition.
-      # @return [TrueClass, FalseClass]
-      def check_request_subdued?(check)
-        if check[:subdue] && check[:subdue][:at] == "publisher"
-          action_subdued?(check[:subdue])
-        else
-          false
-        end
-      end
-
       # Determine if an event handler is silenced.
       #
       # @param handler [Hash] definition.
@@ -351,8 +243,6 @@ module Sensu
           "handler does not handle event severity"
         when handler_silenced?(handler, event)
           "handler is silenced"
-        when handler_subdued?(handler, event)
-          "handler is subdued"
         end
         if filter_message
           @logger.info(filter_message, details)

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -751,7 +751,7 @@ module Sensu
       def schedule_check_executions(checks)
         checks.each do |check|
           create_check_request = Proc.new do
-            unless check_request_subdued?(check)
+            unless check_subdued?(check)
               publish_check_request(check)
             else
               @logger.info("check request was subdued", :check => check)

--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -118,5 +118,83 @@ module Sensu
       end
       [substituted, unmatched_tokens]
     end
+
+    # Determine if a period of time (window) is subdued. The
+    # provided condition must have a `:begin` and `:end` time, eg.
+    # "11:30:00 PM", or `false` will be returned.
+    #
+    # @param condition [Hash]
+    # @option condition [String] :begin time.
+    # @option condition [String] :end time.
+    # @return [TrueClass, FalseClass]
+    def subdue_time?(condition)
+      if condition.has_key?(:begin) && condition.has_key?(:end)
+        begin_time = Time.parse(condition[:begin])
+        end_time = Time.parse(condition[:end])
+        if end_time < begin_time
+          if Time.now < end_time
+            begin_time = Time.parse("12:00:00 AM")
+          else
+            end_time = Time.parse("11:59:59 PM")
+          end
+        end
+        Time.now >= begin_time && Time.now <= end_time
+      else
+        false
+      end
+    end
+
+    # Determine if the current day is subdued. The provided
+    # condition must have a list of `:days`, or false will be
+    # returned.
+    #
+    # @param condition [Hash]
+    # @option condition [Array] :days of the week to subdue.
+    # @return [TrueClass, FalseClass]
+    def subdue_days?(condition)
+      if condition.has_key?(:days)
+        days = condition[:days].map(&:downcase)
+        days.include?(Time.now.strftime("%A").downcase)
+      else
+        false
+      end
+    end
+
+    # Determine if there is an exception a period of time (window)
+    # that is subdued. The provided condition must have an
+    # `:exception`, containing one or more `:begin` and `:end`
+    # times, eg. "11:30:00 PM", or `false` will be returned. If
+    # there are any exceptions to a subdued period of time, `true`
+    # will be returned.
+    #
+    # @param condition [Hash]
+    # @option condition [Hash] :exceptions array of `:begin` and
+    #   `:end` times.
+    # @return [TrueClass, FalseClass]
+    def subdue_exception?(condition)
+      if condition.has_key?(:exceptions)
+        condition[:exceptions].any? do |exception|
+          Time.now >= Time.parse(exception[:begin]) && Time.now <= Time.parse(exception[:end])
+        end
+      else
+        false
+      end
+    end
+
+    # Determine if a check is subdued, by conditions set in the check
+    # definition. If any of the conditions are true, without an
+    # exception, the check is subdued. This method makes use of
+    # `subdue_time?()`, `subdue_days?()`, and subdue_exception?().
+    #
+    # @param check [Hash] definition.
+    # @return [TrueClass, FalseClass]
+    def check_subdued?(check)
+      if check[:subdue]
+        subdued = subdue_time?(check[:subdue]) || subdue_days?(check[:subdue])
+        subdued && !subdue_exception?(check[:subdue])
+      else
+        false
+      end
+    end
   end
 end

--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -119,15 +119,15 @@ module Sensu
       [substituted, unmatched_tokens]
     end
 
-    # Determine if the current time falls within a time window
-    # condition. The provided condition must have a `:begin` and
-    # `:end` time, eg. "11:30:00 PM", or `false` will be returned.
+    # Determine if the current time falls within a time window. The
+    # provided condition must have a `:begin` and `:end` time, eg.
+    # "11:30:00 PM", or `false` will be returned.
     #
     # @param condition [Hash]
     # @option condition [String] :begin time.
     # @option condition [String] :end time.
     # @return [TrueClass, FalseClass]
-    def time_match?(condition)
+    def in_time_window?(condition)
       if condition.has_key?(:begin) && condition.has_key?(:end)
         begin_time = Time.parse(condition[:begin])
         end_time = Time.parse(condition[:end])
@@ -152,18 +152,18 @@ module Sensu
     # @param conditions [Hash]
     # @option conditions [String] :days of the week.
     # @return [TrueClass, FalseClass]
-    def in_time_window?(conditions)
+    def in_time_windows?(conditions)
       in_window = false
-      window_days = conditions[:days]
+      window_days = conditions[:days] || {}
       if window_days[:all]
         in_window = window_days[:all].any? do |condition|
-          time_match?(condition)
+          in_time_window?(condition)
         end
       end
       current_day = Time.now.strftime("%A").downcase.to_sym
       if !in_window && window_days[current_day]
         in_window = window_days[current_day].any? do |condition|
-          time_match?(condition)
+          in_time_window?(condition)
         end
       end
       in_window
@@ -177,7 +177,7 @@ module Sensu
     # @return [TrueClass, FalseClass]
     def check_subdued?(check)
       if check[:subdue]
-        in_time_window?(check[:subdue])
+        in_time_windows?(check[:subdue])
       else
         false
       end

--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -144,54 +144,40 @@ module Sensu
       end
     end
 
-    # Determine if the current day is subdued. The provided
-    # condition must have a list of `:days`, or false will be
-    # returned.
+    # Determine if subdue conditions for one or more days of the week
+    # are met. If a day of the week is provided, it can provide one or
+    # more conditions, each with a `:begin` and `:end` time, eg.
+    # "11:30:00 PM", or `false` will be returned.
     #
-    # @param condition [Hash]
-    # @option condition [Array] :days of the week to subdue.
+    # @param conditions [Hash]
+    # @option conditions [String] :days of the week.
     # @return [TrueClass, FalseClass]
-    def subdue_days?(condition)
-      if condition.has_key?(:days)
-        days = condition[:days].map(&:downcase)
-        days.include?(Time.now.strftime("%A").downcase)
-      else
-        false
-      end
-    end
-
-    # Determine if there is an exception a period of time (window)
-    # that is subdued. The provided condition must have an
-    # `:exception`, containing one or more `:begin` and `:end`
-    # times, eg. "11:30:00 PM", or `false` will be returned. If
-    # there are any exceptions to a subdued period of time, `true`
-    # will be returned.
-    #
-    # @param condition [Hash]
-    # @option condition [Hash] :exceptions array of `:begin` and
-    #   `:end` times.
-    # @return [TrueClass, FalseClass]
-    def subdue_exception?(condition)
-      if condition.has_key?(:exceptions)
-        condition[:exceptions].any? do |exception|
-          Time.now >= Time.parse(exception[:begin]) && Time.now <= Time.parse(exception[:end])
+    def subdued?(conditions)
+      subdued = false
+      subdued_days = conditions[:days]
+      if subdued_days[:all]
+        subdued = subdued_days[:all].any? do |condition|
+          subdue_time?(condition)
         end
-      else
-        false
       end
+      current_day = Time.now.strftime("%A").downcase.to_sym
+      if !subdued && subdued_days[current_day]
+        subdued = subdued_days[current_day].any? do |condition|
+          subdue_time?(condition)
+        end
+      end
+      subdued
     end
 
     # Determine if a check is subdued, by conditions set in the check
     # definition. If any of the conditions are true, without an
-    # exception, the check is subdued. This method makes use of
-    # `subdue_time?()`, `subdue_days?()`, and subdue_exception?().
+    # exception, the check is subdued.
     #
     # @param check [Hash] definition.
     # @return [TrueClass, FalseClass]
     def check_subdued?(check)
       if check[:subdue]
-        subdued = subdue_time?(check[:subdue]) || subdue_days?(check[:subdue])
-        subdued && !subdue_exception?(check[:subdue])
+        subdued?(check[:subdue])
       else
         false
       end

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.0.1"
   s.add_dependency "sensu-json", "2.0.0"
   s.add_dependency "sensu-logger", "1.2.0"
-  s.add_dependency "sensu-settings", "8.0.0"
+  s.add_dependency "sensu-settings", "9.1.0"
   s.add_dependency "sensu-extension", "1.5.0"
   s.add_dependency "sensu-extensions", "1.6.0"
   s.add_dependency "sensu-transport", "6.0.0"

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -286,8 +286,14 @@ describe "Sensu::Client::Process" do
             check.merge(
               :name => "subdued",
               :subdue => {
-                :begin => (Time.now - 3600).strftime("%l:00 %p").strip,
-                :end => (Time.now + 3600).strftime("%l:00 %p").strip
+                :days => {
+                  :all => [
+                    {
+                      :begin => (Time.now - 3600).strftime("%l:00 %p").strip,
+                      :end => (Time.now + 3600).strftime("%l:00 %p").strip
+                    }
+                  ]
+                }
               }
             ),
             check

--- a/spec/config.json
+++ b/spec/config.json
@@ -18,6 +18,31 @@
           "environment": "production"
         }
       }
+    },
+    "offhours": {
+      "attributes": {
+        "client": {
+          "environment": "production"
+        }
+      },
+      "when": {
+        "days": {
+          "all": [
+            {
+              "begin": "5:00 PM",
+              "end": "8:00 AM"
+            }
+          ]
+        }
+      }
+    },
+    "time": {
+      "attributes": {
+        "action": "create"
+      },
+      "when": {
+        "days": {}
+      }
     }
   },
   "mutators": {

--- a/spec/config.json
+++ b/spec/config.json
@@ -38,10 +38,7 @@
     },
     "time": {
       "attributes": {
-        "action": "create"
-      },
-      "when": {
-        "days": {}
+        "action": "resolve"
       }
     }
   },

--- a/spec/server/filter_spec.rb
+++ b/spec/server/filter_spec.rb
@@ -121,12 +121,18 @@ describe "Sensu::Server::Filter" do
     async_wrapper do
       @server.event_filter("time", @event) do |filtered|
         expect(filtered).to be(true)
-        @server.settings[:filters][:time][:when][:days][:all] = [
-          {
-            :begin => (Time.now - 3600).strftime("%l:00 %p").strip,
-            :end => (Time.now + 3600).strftime("%l:00 %p").strip
+        @server.settings[:filters][:time] = {
+          :when => {
+            :days => {
+              :all => [
+                {
+                  :begin => (Time.now + 3600).strftime("%l:00 %p").strip,
+                  :end => (Time.now + 5400).strftime("%l:00 %p").strip
+                }
+              ]
+            }
           }
-        ]
+        }
         @server.event_filter("time", @event) do |filtered|
           expect(filtered).to be(false)
           async_done

--- a/spec/server/filter_spec.rb
+++ b/spec/server/filter_spec.rb
@@ -7,8 +7,6 @@ describe "Sensu::Server::Filter" do
 
   before do
     @server = Sensu::Server::Process.new(options)
-    settings = Sensu::Settings.get(options)
-    @filters = settings[:filters]
     @handler = {}
     @event = event_template
   end
@@ -114,6 +112,24 @@ describe "Sensu::Server::Filter" do
               end
             end
           end
+        end
+      end
+    end
+  end
+
+  it "can filter events for a specific time window" do
+    async_wrapper do
+      @server.event_filter("time", @event) do |filtered|
+        expect(filtered).to be(true)
+        @server.settings[:filters][:time][:when][:days][:all] = [
+          {
+            :begin => (Time.now - 3600).strftime("%l:00 %p").strip,
+            :end => (Time.now + 3600).strftime("%l:00 %p").strip
+          }
+        ]
+        @server.event_filter("time", @event) do |filtered|
+          expect(filtered).to be(false)
+          async_done
         end
       end
     end

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -107,59 +107,53 @@ describe "Sensu::Utilities" do
   it "can determine if a check is subdued" do
     check = {}
     expect(check_subdued?(check)).to be(false)
-    check[:subdue] = {
-      :begin => (Time.now - 3600).strftime("%l:00 %p").strip,
-      :end => (Time.now + 3600).strftime("%l:00 %p").strip
-    }
-    expect(check_subdued?(check)).to be(true)
-    check[:subdue] = {
-      :begin => (Time.now + 3600).strftime("%l:00 %p").strip,
-      :end => (Time.now + 7200).strftime("%l:00 %p").strip
+    check = {
+      :subdue => {
+        :days => {}
+      }
     }
     expect(check_subdued?(check)).to be(false)
-    check[:subdue] = {
-      :begin => (Time.now - 3600).strftime("%l:00 %p").strip,
-      :end => (Time.now - 7200).strftime("%l:00 %p").strip
-    }
-    expect(check_subdued?(check)).to be(true)
-    check[:subdue] = {
-      :begin => (Time.now + 3600).strftime("%l:00 %p").strip,
-      :end => (Time.now - 7200).strftime("%l:00 %p").strip
-    }
+    check[:subdue][:days][:all] = []
     expect(check_subdued?(check)).to be(false)
-    check[:subdue] = {
-      :days => [
-        Time.now.strftime("%A"),
-        "wednesday"
-      ]
-    }
-    expect(check_subdued?(check)).to be(true)
-    check[:subdue] = {
-      :days => [
-        (Time.now + 86400).strftime("%A"),
-        (Time.now + 172800).strftime("%A")
-      ]
-    }
+    check[:subdue][:days][:all] = [
+      {
+        :begin => (Time.now + 3600).strftime("%l:00 %p").strip,
+        :end => (Time.now + 4200).strftime("%l:00 %p").strip
+      }
+    ]
     expect(check_subdued?(check)).to be(false)
-    check[:subdue] = {
-      :days => %w[sunday monday tuesday wednesday thursday friday saturday],
-      :exceptions => [
-        {
-          :begin => (Time.now + 3600).rfc2822,
-          :end => (Time.now + 7200)
-        }
-      ]
-    }
+    check[:subdue][:days][:all] = [
+      {
+        :begin => (Time.now - 3600).strftime("%l:00 %p").strip,
+        :end => (Time.now + 3600).strftime("%l:00 %p").strip
+      }
+    ]
     expect(check_subdued?(check)).to be(true)
-    check[:subdue] = {
-      :days => %w[sunday monday tuesday wednesday thursday friday saturday],
-      :exceptions => [
-        {
-          :begin => (Time.now - 3600).rfc2822,
-          :end => (Time.now + 3600).rfc2822
-        }
-      ]
-    }
+    check[:subdue][:days].delete(:all)
+    expect(check_subdued?(check)).to be(false)
+    current_day = Time.now.strftime("%A").downcase.to_sym
+    check[:subdue][:days][current_day] = [
+      {
+        :begin => (Time.now + 3600).strftime("%l:00 %p").strip,
+        :end => (Time.now + 4200).strftime("%l:00 %p").strip
+      }
+    ]
+    expect(check_subdued?(check)).to be(false)
+    check[:subdue][:days][current_day] = [
+      {
+        :begin => (Time.now - 3600).strftime("%l:00 %p").strip,
+        :end => (Time.now + 3600).strftime("%l:00 %p").strip
+      }
+    ]
+    expect(check_subdued?(check)).to be(true)
+    check[:subdue][:days].delete(current_day)
+    tomorrow = (Time.now + 86400).strftime("%A").downcase.to_sym
+    check[:subdue][:days][tomorrow] = [
+      {
+        :begin => (Time.now - 3600).strftime("%l:00 %p").strip,
+        :end => (Time.now + 3600).strftime("%l:00 %p").strip
+      }
+    ]
     expect(check_subdued?(check)).to be(false)
   end
 end


### PR DESCRIPTION
## Description
This pull-request implements "Subdue 2.0".

Example time window configuration for check subdue and filter when:

https://gist.github.com/portertech/b219d36d97adbfc80f1c3f08ab3660d2

## Related Issue
Closes https://github.com/sensu/sensu/issues/1390
Closes https://github.com/sensu/sensu/pull/847

## Motivation and Context
Makes it clear that "subdue" applies to check execution schedulers, both pubsub (server) and standalone (client), allowing users to specify time windows when check executions should occur.

Add time windows to Sensu filters via `"when"`, allowing users to specify time windows when a filter is applied to events for an event handler.

## How Has This Been Tested?
Specs have been updated to test check subdue and filter when.

Time window validation is tested in sensu-settings, e.g. https://github.com/sensu/sensu-settings/blob/master/spec/validator_spec.rb#L260 and https://github.com/sensu/sensu-settings/blob/master/spec/validator_spec.rb#L388.

I have manually tested time window validation:

```
{"timestamp":"2016-08-19T11:45:15.632208-0700","level":"fatal","message":"filter when days must be a hash","object":{"attributes":{"action":"resolve"},"when":{},"name":"time"}}
{"timestamp":"2016-08-19T11:46:09.934273-0700","level":"fatal","message":"filter when days must be a hash","object":{"attributes":{"action":"resolve"},"when":{"days":[]},"name":"time"}}
{"timestamp":"2016-08-19T11:46:29.459711-0700","level":"fatal","message":"filter when days must include at least one day of the week or 'all'","object":{"attributes":{"action":"resolve"},"when":{"days":{}},"name":"time"}}
{"timestamp":"2016-08-19T11:46:54.405828-0700","level":"fatal","message":"filter when days must be valid days of the week or 'all'","object":{"attributes":{"action":"resolve"},"when":{"days":{"nope":{}}},"name":"time"}}
{"timestamp":"2016-08-19T11:47:14.189901-0700","level":"fatal","message":"filter when days all must be in an array","object":{"attributes":{"action":"resolve"},"when":{"days":{"all":{}}},"name":"time"}}
{"timestamp":"2016-08-19T11:47:29.176118-0700","level":"fatal","message":"filter when days all must include at least one time window","object":{"attributes":{"action":"resolve"},"when":{"days":{"all":[]}},"name":"time"}}
{"timestamp":"2016-08-19T11:47:45.568031-0700","level":"fatal","message":"filter when day time window must be a hash","object":{"attributes":{"action":"resolve"},"when":{"days":{"all":[[]]}},"name":"time"}}
{"timestamp":"2016-08-19T11:47:59.315910-0700","level":"fatal","message":"filter when day time window begin and end times must be valid","object":{"attributes":{"action":"resolve"},"when":{"days":{"all":[{}]}},"name":"time"}}
{"timestamp":"2016-08-19T11:48:33.633027-0700","level":"fatal","message":"filter when day time window begin and end times must be valid","object":{"attributes":{"action":"resolve"},"when":{"days":{"all":[{"begin":"5:00 PM","end":"nope"}]}},"name":"time"}}
```

## Screenshots (if appropriate):

N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.