### PR TITLE
Make ttl_status configurable

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -879,7 +879,8 @@ module Sensu
                   client_name = result_key.split(":").first
                   check[:output] = "Last check execution was "
                   check[:output] << "#{time_since_last_execution} seconds ago"
-                  check[:status] = 1
+                  check[:output] << ". (Threshold: #{check[:ttl]} seconds)"
+                  check[:status] = @settings[:ttl_status] || 1
                   publish_check_result(client_name, check)
                 end
               else

--- a/spec/config.json
+++ b/spec/config.json
@@ -178,5 +178,6 @@
     },
     "empty": {},
     "localhost": "fail"
-  }
+  },
+  "ttl_status": 2
 }

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -612,7 +612,7 @@ describe "Sensu::Server::Process" do
                       expect(events.size).to eq(1)
                       event = Sensu::JSON.load(events["foo"])
                       expect(event[:check][:output]).to match(/Last check execution was 3[0-9] seconds ago/)
-                      expect(event[:check][:status]).to eq(1)
+                      expect(event[:check][:status]).to eq(2)
                       async_done
                     end
                   end


### PR DESCRIPTION
## Description

As discussed in #971, not everyone uses warnings, and would prefer criticals to be default. Making this configurable would be useful.
## Related Issue

Closes #1423 
## Motivation and Context

Solves #971
## How Has This Been Tested?

Spec tests
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
