### PR TITLE
Suppress stale check events when client keepalive event exists

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -624,7 +624,7 @@ module Sensu
       # @param client_name [String] name of client to look up in event registry.
       # @return [TrueClass, FalseClass]
       def keepalive_event_exists?(client_name)
-        @redis.hexists("event:#{client_name}", "keepalive") do |event_exists|
+        @redis.hexists("events:#{client_name}", "keepalive") do |event_exists|
           yield(event_exists)
         end
       end

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -619,6 +619,16 @@ module Sensu
         end
       end
 
+      # Determine if a keepalive incident exists in the event registry.
+      #
+      # @param client_name [String] name of client to look up in event registry.
+      # @return [TrueClass, FalseClass]
+      def keepalive_event_exists?(client_name)
+        @redis.hexists("event:#{client_name}", "keepalive") do |event_exists|
+          yield(event_exists)
+        end
+      end
+
       # Process a check result, storing its data, inspecting its
       # contents, and taking the appropriate actions (eg. update the
       # event registry). The `@in_progress[:check_results]` counter is
@@ -941,10 +951,14 @@ module Sensu
                 time_since_last_execution = Time.now.to_i - check[:executed]
                 if time_since_last_execution >= check[:ttl]
                   client_name = result_key.split(":").first
-                  check[:output] = "Last check execution was "
-                  check[:output] << "#{time_since_last_execution} seconds ago"
-                  check[:status] = 1
-                  publish_check_result(client_name, check)
+                  keepalive_event_exists?(client_name) do |event_exists|
+                    unless event_exists
+                      check[:output] = "Last check execution was "
+                      check[:output] << "#{time_since_last_execution} seconds ago"
+                      check[:status] = 1
+                      publish_check_result(client_name, check)
+                    end
+                  end
                 end
               else
                 @redis.srem("ttl", result_key)

--- a/spec/config.json
+++ b/spec/config.json
@@ -92,14 +92,14 @@
     "tcp": {
       "type": "tcp",
       "socket": {
-        "host": "localhost",
+        "host": "127.0.0.1",
         "port": 1234
       }
     },
     "udp": {
       "type": "udp",
       "socket": {
-        "host": "localhost",
+        "host": "127.0.0.1",
         "port": 1234
       }
     },

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -151,7 +151,7 @@ module Helpers
     if request_options[:body].is_a?(Hash) || request_options[:body].is_a?(Array)
       request_options[:body] = Sensu::JSON.dump(request_options[:body])
     end
-    http = EM::HttpRequest.new("http://localhost:4567#{uri}").send(method, request_options)
+    http = EM::HttpRequest.new("http://127.0.0.1:4567#{uri}").send(method, request_options)
     http.callback do
       body = case
       when http.response.empty?


### PR DESCRIPTION
## Description

Inspired by #1282, this pull request includes changes to suppress stale check events (i.e. checks with an expired ttl) when the relevant client has an active keepalive event.

Also updates spec config.json and API query helper to use `127.0.0.1` instead of `localhost` to help those of us with working IPv6 stacks :)

## Related Issue

Closes #1282

## Motivation and Context

Motivated by a desire to reduce the noise and boost the signal :)

#1282 and https://github.com/sensu/sensu/issues/861#issuecomment-130136052 describe the desire to suppress stale check events if keepalive is also alerting.

## How Has This Been Tested?

Added unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
