### PR TITLE
Handle SyntaxError exceptions from eval filters

### DIFF
--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -115,7 +115,7 @@ module Sensu
           begin
             value = Marshal.load(Marshal.dump(raw_value))
             !!Sandbox.eval(eval_string, value)
-          rescue => error
+          rescue StandardError, SyntaxError => error
             @logger.error("filter attribute eval error", {
               :event => event,
               :raw_eval_string => raw_eval_string,

--- a/spec/server/filter_spec.rb
+++ b/spec/server/filter_spec.rb
@@ -173,4 +173,11 @@ describe "Sensu::Server::Filter" do
       end
     end
   end
+
+  it "can catch SyntaxErrors in eval filters" do
+    attributes = {
+      :occurrences => "eval: raise SyntaxError"
+    }
+    expect(@server.filter_attributes_match?(@event, attributes)).to be(false)
+  end
 end


### PR DESCRIPTION
## Description

When a filter contains a syntax error, the server currently raises an unhandled
`SyntaxError` exception, causing the daemon process to exit. This change explicitly
catches `SyntaxError` exceptions in addition to the `StandardError` exception
class which is caught by default when calling `rescue`.

## Related Issue
Closes sensu/sensu-enterprise#159

## Motivation and Context

I believe that ideally server should not crash due to configuration syntax errors once it has begun running. As we lack event context to  reasonably `eval` every filter at startup checking for syntax errors, I think it makes more sense to gracefully handle this exception and log the incidence.

## How Has This Been Tested?

Added a test to the filter spec to raise a `SyntaxError` exception and assert that 
it is handled with a false match on the filter.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.