### PR TITLE
[server] ensure per-client subscription is added when creating a proxy client

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -575,7 +575,7 @@ module Sensu
         {
           :name => name,
           :address => "unknown",
-          :subscriptions => [],
+          :subscriptions => ["client:#{name}"],
           :keepalives => false,
           :version => VERSION
         }

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -488,6 +488,7 @@ describe "Sensu::Server::Process" do
                   redis.hget("events:i-888888", "test") do |event_json|
                     event = Sensu::JSON.load(event_json)
                     expect(event[:client][:address]).to eq("unknown")
+                    expect(event[:client][:subscriptions]).to include("client:i-888888")
                     async_done
                   end
                 end


### PR DESCRIPTION
## Description

In sensu/sensu-settings#40 we added per-client subscriptions which are a requirement for per-client native silencing added in 0.26, but this implementation doesn't cover proxy clients.

When processing events, the server calls `retrieve_client` to request client data from the registry using the client name. If a client with is not defined, we create a minimal entry in the client registry to represent the proxy client.

This change ensures that per-client subscriptions are added when a proxy client is registered.

## Related Issue

Closes #1439

## Motivation and Context

Fixes per-client silencing for proxy clients.

## How Has This Been Tested?

Added a unit test to ensure proxy clients are created with a per-client subscription.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.