### PR TITLE
[api/silenced] allow for retrieving subscriptions containing colons

### DIFF
--- a/lib/sensu/api/routes/silenced.rb
+++ b/lib/sensu/api/routes/silenced.rb
@@ -3,7 +3,7 @@ module Sensu
     module Routes
       module Silenced
         SILENCED_URI = /^\/silenced$/
-        SILENCED_SUBSCRIPTION_URI = /^\/silenced\/subscriptions\/([\w\.-]+)$/
+        SILENCED_SUBSCRIPTION_URI = /^\/silenced\/subscriptions\/([\w\.-:]+)$/
         SILENCED_CHECK_URI = /^\/silenced\/checks\/([\w\.-]+)$/
         SILENCED_CLEAR_URI = /^\/silenced\/clear$/
 

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -1286,6 +1286,43 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can create and retrieve silenced registry entry with a subscription containing a colon" do
+    api_test do
+      options = {
+        :body => {
+          :subscription => "client:test",
+          :check => "test",
+          :expire => 3600,
+          :reason => "testing",
+          :creator => "rspec",
+          :expire_on_resolve => true
+        }
+      }
+      api_request("/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(201)
+        redis.get("silence:client:test:test") do |silenced_info_json|
+          silenced_info = Sensu::JSON.load(silenced_info_json)
+          expect(silenced_info[:id]).to eq("client:test:test")
+          expect(silenced_info[:subscription]).to eq("client:test")
+          expect(silenced_info[:check]).to eq("test")
+          expect(silenced_info[:reason]).to eq("testing")
+          expect(silenced_info[:creator]).to eq("rspec")
+          expect(silenced_info[:expire_on_resolve]).to eq(true)
+          redis.ttl("silence:client:test:test") do |ttl|
+            expect(ttl).to be_within(10).of(3600)
+            async_done
+          end
+        end
+        api_request("/silenced/subscriptions/client:test") do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Hash)
+          expect(body).to eq(result_template(@check))
+          async_done
+        end
+      end
+    end
+  end
+
   it "can not create a silenced registry entry when missing a subscription and/or check" do
     api_test do
       options = {


### PR DESCRIPTION
## Description

This change modifies the regexp to ensure we can query the api for silenced
registry entries by subscription when the subscription name contains a colon.

## Related Issue

Closes #1449 

## Motivation and Context

The regexp for matching valid subscriptions under /silenced/subscriptions route
excludes valid subscriptions containing colons, e.g. `client:foo`, `roundrobin:bar`.

## How Has This Been Tested?

Added API unit test to ensure that a silence for `client:test` subscription can be both created and read back from the /silenced and /silenced/subscriptions routes, respectively. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.