### PR TITLE
[api] updating publish_check_result to set client signature when present

### DIFF
--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -301,6 +301,48 @@ describe "Sensu::API::Process" do
         api_request("/events/i-424242/test", :delete) do |http, body|
           expect(http.response_header.status).to eq(202)
           expect(body).to include(:issued)
+          timer(0.5) do
+            redis.hget("events:i-424242", "test") do |event_json|
+              expect(event_json.nil?).to be_true
+            end
+          end
+        end
+      end
+    end
+  end
+
+  it "can delete an event when the client has a signature" do
+    @server = Sensu::Server::Process.new(options)
+    async_wrapper do
+      @server.setup_connections do
+        @server.setup_keepalives
+        @server.setup_results
+        keepalive = client_template
+        keepalive[:timestamp] = epoch
+        keepalive[:signature] = "foo"
+        transport.publish(:direct, "keepalives", Sensu::JSON.dump(keepalive))
+        timer(1) do
+          redis.get("client:i-424242:signature") do |signature|
+            expect(signature).to eq("foo")
+            check_result = result_template
+            check_result[:signature] = "foo"
+            check_result[:check][:name] = 'signature_test'
+            @server.process_check_result(check_result)
+            timer(1) do
+              api_test do
+                api_request("/events/i-424242/signature_test", :delete) do |http, body|
+                  expect(http.response_header.status).to eq(202)
+                  expect(body).to include(:issued)
+                  timer(2) do
+                    redis.hget("events:i-424242", "signature_test") do |event_json|
+                      expect(event_json).to be_nil
+                      async_done
+                    end
+                  end
+                end
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
## Description

When events are deleted via the API, the `publish_check_result` helper is used to issue check result which resets the event's status to `0`. Currently this mechanism does not include  the client signature when one is set. As a result, the API will return a 202 response code, as if the event were successfully deleted, when in reality the event is not deleted because the check result lacks the required signature.

This change updates the `publish_check_result` helper used by the API when deleting events to ensure that the published check result includes the client signature, provided that a signature for that client is present in the client registry.

## Related Issue

Closes #1435

## Motivation and Context

Failure to delete an event under the circumstances described above constitutes a bug.

## How Has This Been Tested?

Added unit test to validate that events are actually removed from redis.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.