### PR TITLE
use sensu-settings 9.2.0 to ensure client defaults to {}

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.0.1"
 
 gem "sensu-json", "2.0.0"
 gem "sensu-logger", "1.2.0"
-gem "sensu-settings", "9.1.1"
+gem "sensu-settings", "9.2.0"
 gem "sensu-extension", "1.5.0"
 gem "sensu-extensions", "1.7.0"
 gem "sensu-transport", "6.0.0"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.0.1"
   s.add_dependency "sensu-json", "2.0.0"
   s.add_dependency "sensu-logger", "1.2.0"
-  s.add_dependency "sensu-settings", "9.1.1"
+  s.add_dependency "sensu-settings", "9.2.0"
   s.add_dependency "sensu-extension", "1.5.0"
   s.add_dependency "sensu-extensions", "1.7.0"
   s.add_dependency "sensu-transport", "6.0.0"


### PR DESCRIPTION
## Description

This change updates Sensu to depend on version 9.2.0 of sensu-settings.

Requiring this version of sensu-settings changes default value for `client`from `nil` to `{}` (empty hash).

## Related Issue

Closes #1444

## Motivation and Context

In sensu-settings 9.1.1 we attempted to address some regressions which prevent the sensu-server process from successfully starting without a `client` config scope defined. The fix in that version did not prove comprehensive enough, and as a result we've chosen to default the `client` config scope to an empty hash.

## How Has This Been Tested?

Existing tests were updated in sensu/sensu-settings#46 which implements the change we're pulling in here.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.