### PR TITLE
[api/silenced] allow for subscriptions containing colons *and* hyphens

### DIFF
--- a/lib/sensu/api/routes/silenced.rb
+++ b/lib/sensu/api/routes/silenced.rb
@@ -3,7 +3,7 @@ module Sensu
     module Routes
       module Silenced
         SILENCED_URI = /^\/silenced$/
-        SILENCED_SUBSCRIPTION_URI = /^\/silenced\/subscriptions\/([\w\.-:]+)$/
+        SILENCED_SUBSCRIPTION_URI = /^\/silenced\/subscriptions\/([\w\.:-]+)$/
         SILENCED_CHECK_URI = /^\/silenced\/checks\/([\w\.-]+)$/
         SILENCED_CLEAR_URI = /^\/silenced\/clear$/
 

--- a/lib/sensu/api/routes/silenced.rb
+++ b/lib/sensu/api/routes/silenced.rb
@@ -3,8 +3,8 @@ module Sensu
     module Routes
       module Silenced
         SILENCED_URI = /^\/silenced$/
-        SILENCED_SUBSCRIPTION_URI = /^\/silenced\/subscriptions\/([\w\.:-]+)$/
-        SILENCED_CHECK_URI = /^\/silenced\/checks\/([\w\.-]+)$/
+        SILENCED_SUBSCRIPTION_URI = /^\/silenced\/subscriptions\/([\w\.\-:]+)$/
+        SILENCED_CHECK_URI = /^\/silenced\/checks\/([\w\.\-]+)$/
         SILENCED_CLEAR_URI = /^\/silenced\/clear$/
 
         # Fetch silenced registry entries for the provided silenced

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -1335,24 +1335,24 @@ describe "Sensu::API::Process" do
     "load-balancer",
     "load_balancer",
     "loadbalancer"
-  ].each do |sub|
-    it "can create and retrieve silenced registry entry with a subscription e.g. #{sub}" do
+  ].each do |subscription|
+    it "can create and retrieve silenced registry entry with a subscription e.g. #{subscription}" do
       api_test do
         options = {
           :body => {
-            :subscription => sub,
+            :subscription => subscription,
             :check => "test"
           }
         }
         api_request("/silenced", :post, options) do |http, body|
           expect(http.response_header.status).to eq(201)
-          redis.get("silence:#{sub}:test") do |silenced_info_json|
+          redis.get("silence:#{subscription}:test") do |silenced_info_json|
             timer(1) do
-              api_request("/silenced/subscriptions/#{sub}") do |http, body|
+              api_request("/silenced/subscriptions/#{subscription}") do |http, body|
                 expect(http.response_header.status).to eq(200)
                 expect(body).to be_kind_of(Array)
                 silence = body.last
-                expect(silence[:id]).to eq("#{sub}:test")
+                expect(silence[:id]).to eq("#{subscription}:test")
                 async_done
               end
             end

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -1328,11 +1328,11 @@ describe "Sensu::API::Process" do
     end
   end
 
-  it "can create and retrieve silenced registry entry with a subscription containing a colon" do
+  it "can create and retrieve silenced registry entry with a subscription containing both a colon and a hyphen" do
     api_test do
       options = {
         :body => {
-          :subscription => "client:test",
+          :subscription => "client:my-test-client",
           :check => "test",
           :expire => 3600,
           :reason => "testing",
@@ -1342,20 +1342,20 @@ describe "Sensu::API::Process" do
       }
       api_request("/silenced", :post, options) do |http, body|
         expect(http.response_header.status).to eq(201)
-        redis.get("silence:client:test:test") do |silenced_info_json|
+        redis.get("silence:client:my-test-client:test") do |silenced_info_json|
           silenced_info = Sensu::JSON.load(silenced_info_json)
-          expect(silenced_info[:id]).to eq("client:test:test")
-          expect(silenced_info[:subscription]).to eq("client:test")
+          expect(silenced_info[:id]).to eq("client:my-test-client:test")
+          expect(silenced_info[:subscription]).to eq("client:my-test-client")
           expect(silenced_info[:check]).to eq("test")
           expect(silenced_info[:reason]).to eq("testing")
           expect(silenced_info[:creator]).to eq("rspec")
           expect(silenced_info[:expire_on_resolve]).to eq(true)
-          redis.ttl("silence:client:test:test") do |ttl|
+          redis.ttl("silence:client:my-test-client:test") do |ttl|
             expect(ttl).to be_within(10).of(3600)
             async_done
           end
         end
-        api_request("/silenced/subscriptions/client:test") do |http, body|
+        api_request("/silenced/subscriptions/client:my-test-client") do |http, body|
           expect(http.response_header.status).to eq(200)
           expect(body).to be_kind_of(Hash)
           expect(body).to eq(result_template(@check))

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -1328,38 +1328,35 @@ describe "Sensu::API::Process" do
     end
   end
 
-  it "can create and retrieve silenced registry entry with a subscription containing both a colon and a hyphen" do
-    api_test do
-      options = {
-        :body => {
-          :subscription => "client:my-test-client",
-          :check => "test",
-          :expire => 3600,
-          :reason => "testing",
-          :creator => "rspec",
-          :expire_on_resolve => true
+  [
+    "client:my-test-client",
+    "roundrobin:load_balancer",
+    "roundrobin:foo_bar-baz",
+    "load-balancer",
+    "load_balancer",
+    "loadbalancer"
+  ].each do |sub|
+    it "can create and retrieve silenced registry entry with a subscription e.g. #{sub}" do
+      api_test do
+        options = {
+          :body => {
+            :subscription => sub,
+            :check => "test"
+          }
         }
-      }
-      api_request("/silenced", :post, options) do |http, body|
-        expect(http.response_header.status).to eq(201)
-        redis.get("silence:client:my-test-client:test") do |silenced_info_json|
-          silenced_info = Sensu::JSON.load(silenced_info_json)
-          expect(silenced_info[:id]).to eq("client:my-test-client:test")
-          expect(silenced_info[:subscription]).to eq("client:my-test-client")
-          expect(silenced_info[:check]).to eq("test")
-          expect(silenced_info[:reason]).to eq("testing")
-          expect(silenced_info[:creator]).to eq("rspec")
-          expect(silenced_info[:expire_on_resolve]).to eq(true)
-          redis.ttl("silence:client:my-test-client:test") do |ttl|
-            expect(ttl).to be_within(10).of(3600)
-            async_done
+        api_request("/silenced", :post, options) do |http, body|
+          expect(http.response_header.status).to eq(201)
+          redis.get("silence:#{sub}:test") do |silenced_info_json|
+            timer(1) do
+              api_request("/silenced/subscriptions/#{sub}") do |http, body|
+                expect(http.response_header.status).to eq(200)
+                expect(body).to be_kind_of(Array)
+                silence = body.last
+                expect(silence[:id]).to eq("#{sub}:test")
+                async_done
+              end
+            end
           end
-        end
-        api_request("/silenced/subscriptions/client:my-test-client") do |http, body|
-          expect(http.response_header.status).to eq(200)
-          expect(body).to be_kind_of(Hash)
-          expect(body).to eq(result_template(@check))
-          async_done
         end
       end
     end


### PR DESCRIPTION
## Description

In #1450 we introduced a change to the regexp for validating requests to the `/silenced/subscriptions/:subscription` endpoint, but this change introduced a regression preventing the handling of subscriptions that also contain a hyphen (e.g. HTTP GET against `/silenced/subscriptions/client:foo` works but  HTTP GET agains `/silenced/subscriptions/client:foo-bar` does not).

~~Transposing the positions of `-` and `:` in the regex seems to solve the problem.~~ 

In the interests of clarity and readability I've opted to escape the hyphen rather than change its position.

## Related Issue

Closes #1449 

## Motivation and Context

The regexp for matching valid subscriptions under /silenced/subscriptions route
excludes valid subscriptions containing colons and hyphens, e.g. `client:foo-bar`.

## How Has This Been Tested?

Expanded the unit test coverage to test a variety of subscriptions using colons, hyphens and underscores in various combinations.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

