### PR TITLE
[gemspec] update sensu-settings to 9.2.1

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.0.1"
 
 gem "sensu-json", "2.0.0"
 gem "sensu-logger", "1.2.0"
-gem "sensu-settings", "9.2.0"
+gem "sensu-settings", "9.2.1"
 gem "sensu-extension", "1.5.0"
 gem "sensu-extensions", "1.7.0"
 gem "sensu-transport", "6.0.0"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.0.1"
   s.add_dependency "sensu-json", "2.0.0"
   s.add_dependency "sensu-logger", "1.2.0"
-  s.add_dependency "sensu-settings", "9.2.0"
+  s.add_dependency "sensu-settings", "9.2.1"
   s.add_dependency "sensu-extension", "1.5.0"
   s.add_dependency "sensu-extensions", "1.7.0"
   s.add_dependency "sensu-transport", "6.0.0"


### PR DESCRIPTION
## Description

Update sensu-settings from 9.2.0 to 9.2.1 to address issue described in https://github.com/sensu/sensu-settings/issues/47

## Related Issue

Closes https://github.com/sensu/sensu-settings/issues/47
Closes #1231

## Motivation and Context

This change pulls in a fix for the spurious validation error described in https://github.com/sensu/sensu-settings/issues/47, 

## How Has This Been Tested?

Manually installed sensu-settings 9.2.1 in a testing environment and was not able to reproduce error described in https://github.com/sensu/sensu-settings/issues/47

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.