### PR TITLE
[server/filter] log filter name when event is filtered

### DIFF
--- a/spec/server/filter_spec.rb
+++ b/spec/server/filter_spec.rb
@@ -88,10 +88,12 @@ describe "Sensu::Server::Filter" do
   it "can filter an event using a filter" do
     async_wrapper do
       @event[:client][:environment] = "production"
-      @server.event_filter("production", @event) do |filtered|
+      @server.event_filter("production", @event) do |filtered, filter_name|
         expect(filtered).to be(false)
-        @server.event_filter("development", @event) do |filtered|
+        expect(filter_name).to eq("production")
+        @server.event_filter("development", @event) do |filtered, filter_name|
           expect(filtered).to be(true)
+          expect(filter_name).to eq("development")
           @server.event_filter("nonexistent", @event) do |filtered|
             expect(filtered).to be(false)
             handler = {


### PR DESCRIPTION
## Description

As described in https://github.com/sensu/sensu/issues/1422, we want the "event was filtered" log message to include the name of the matching filter. This change implements that feature.

## Related Issue

Closes #1422 

## Motivation and Context

As handlers can be configured with multiple filters, it can be useful to know which filter actually matched a given event for troubleshooting and other purposes.

## How Has This Been Tested?

Added assertions to existing specs to ensure filter name was returned.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the method documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.