### PR TITLE
Add Silenced API endpoint for retrieving entries by ID

### DIFF
--- a/lib/sensu/api/routes.rb
+++ b/lib/sensu/api/routes.rb
@@ -53,6 +53,7 @@ module Sensu
         [RESULTS_CLIENT_URI, :get_results_client],
         [RESULT_URI, :get_result],
         [SILENCED_URI, :get_silenced],
+        [SILENCED_ID_URI, :get_silenced_id],
         [SILENCED_SUBSCRIPTION_URI, :get_silenced_subscription],
         [SILENCED_CHECK_URI, :get_silenced_check]
       ]

--- a/lib/sensu/api/routes/silenced.rb
+++ b/lib/sensu/api/routes/silenced.rb
@@ -46,7 +46,7 @@ module Sensu
         # POST /silenced
         def post_silenced
           rules = {
-            :subscription => {:type => String, :nil_ok => true},
+            :subscription => {:type => String, :nil_ok => true, :regex => /\A[\w\.\-\:]+\z/},
             :check => {:type => String, :nil_ok => true, :regex => /\A[\w\.-]+\z/},
             :expire => {:type => Integer, :nil_ok => true},
             :reason => {:type => String, :nil_ok => true},

--- a/lib/sensu/api/routes/silenced.rb
+++ b/lib/sensu/api/routes/silenced.rb
@@ -3,7 +3,7 @@ module Sensu
     module Routes
       module Silenced
         SILENCED_URI = /^\/silenced$/
-        SILENCED_ID_URI = /^\/silenced\/ids\/([\w\.\-\*]+:[\w\.\-\*]+)$/
+        SILENCED_ID_URI = /^\/silenced\/ids\/([\w\.\-\*\:]+)$/
         SILENCED_SUBSCRIPTION_URI = /^\/silenced\/subscriptions\/([\w\.\-:]+)$/
         SILENCED_CHECK_URI = /^\/silenced\/checks\/([\w\.\-]+)$/
         SILENCED_CLEAR_URI = /^\/silenced\/clear$/
@@ -115,7 +115,7 @@ module Sensu
           id = parse_uri(SILENCED_ID_URI).first
           @redis.smembers("silenced") do |silenced_keys|
             silenced_keys.select! do |key|
-              key =~ /.#{id.gsub('*', '\*')}$/
+              key =~ /#{id.gsub('*', '\*')}$/
             end
             silenced_keys = pagination(silenced_keys)
             fetch_silenced(silenced_keys) do |silenced|

--- a/lib/sensu/api/routes/silenced.rb
+++ b/lib/sensu/api/routes/silenced.rb
@@ -3,6 +3,7 @@ module Sensu
     module Routes
       module Silenced
         SILENCED_URI = /^\/silenced$/
+        SILENCED_ID_URI = /^\/silenced\/ids\/([\w\.\-\*]+:[\w\.\-\*]+)$/
         SILENCED_SUBSCRIPTION_URI = /^\/silenced\/subscriptions\/([\w\.\-:]+)$/
         SILENCED_CHECK_URI = /^\/silenced\/checks\/([\w\.\-]+)$/
         SILENCED_CLEAR_URI = /^\/silenced\/clear$/
@@ -105,6 +106,25 @@ module Sensu
             fetch_silenced(silenced_keys) do |silenced|
               @response_content = silenced
               respond
+            end
+          end
+        end
+
+        # GET /silenced/ids/:id
+        def get_silenced_id
+          id = parse_uri(SILENCED_ID_URI).first
+          @redis.smembers("silenced") do |silenced_keys|
+            silenced_keys.select! do |key|
+              key =~ /.#{id.gsub('*', '\*')}$/
+            end
+            silenced_keys = pagination(silenced_keys)
+            fetch_silenced(silenced_keys) do |silenced|
+              if silenced.empty?
+                not_found!
+              else
+                @response_content = silenced.last
+                respond
+              end
             end
           end
         end

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -1557,16 +1557,12 @@ describe "Sensu::API::Process" do
       end
     end
 
-    it "can retrieve entry for silencing all checks on all subscriptions" do
+    it "cannot create an entry for silencing all checks on all subscriptions" do
       api_test do
         options = { :body => { :subscription => '*' } }
         api_request("/silenced", :post, options) do |http, body|
-          api_request("/silenced/ids/*:*") do |http, body|
-            expect(http.response_header.status).to eq(200)
-            expect(body).to be_kind_of(Hash)
-            expect(body[:id]).to eq("*:*")
-            async_done
-          end
+          expect(http.response_header.status).to eq(400)
+          async_done
         end
       end
     end


### PR DESCRIPTION
## Description

Adds a new endpoint to the [Silenced API]( https://sensuapp.org/docs/latest/reference/silencing.html) for retrieving entries by their ID.

## Related Issue

Closes #1465

## Motivation and Context

As described in #1465, sometimes you just want to retrieve a silencing entry by its known ID, or know if a specific entry exists.

## How Has This Been Tested?

Added unit tests in api process spec.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
