### PR TITLE
update sensu-settings dependency to 9.2.2

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.0.1"
 
 gem "sensu-json", "2.0.1"
 gem "sensu-logger", "1.2.1"
-gem "sensu-settings", "9.2.1"
+gem "sensu-settings", "9.2.2"
 gem "sensu-extension", "1.5.1"
 gem "sensu-extensions", "1.7.1"
 gem "sensu-transport", "6.0.1"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.0.1"
   s.add_dependency "sensu-json", "2.0.1"
   s.add_dependency "sensu-logger", "1.2.1"
-  s.add_dependency "sensu-settings", "9.2.1"
+  s.add_dependency "sensu-settings", "9.2.2"
   s.add_dependency "sensu-extension", "1.5.1"
   s.add_dependency "sensu-extensions", "1.7.1"
   s.add_dependency "sensu-transport", "6.0.1"


### PR DESCRIPTION
## Description

Update sensu-settings dependencies to 9.2.2

## Related Issue

Closes https://github.com/sensu/sensu-build/issues/173

## Motivation and Context

As described in https://github.com/sensu/sensu-build/issues/173, Sensu currently crashes with a fatal exception when attempting to load empty files. This is addressed in https://github.com/sensu/sensu-settings/pull/50, and released in sensu-settings 9.2.2 

## How Has This Been Tested?

Added a unit test in sensu-settings to test that an empty file is treated as an empty JSON array.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.