### PR TITLE
IPv4/IPv6 dual-stack support

### DIFF
--- a/lib/sensu/api/process.rb
+++ b/lib/sensu/api/process.rb
@@ -44,7 +44,7 @@ module Sensu
       # state to `:running`.
       def start
         api = @settings[:api] || {}
-        bind = api[:bind] || "0.0.0.0"
+        bind = api[:bind] || "::"
         port = api[:port] || 4567
         start_http_server(bind, port)
         super


### PR DESCRIPTION
This enables Sensu to have multiple bind addresses for local client sockets, which now listen on IPv4 & IPv6 by default. It also modifies the default API configuration to listen on both IPv4 and IPv6 by default.

In addition to the current changes, support for multiple bind addresses within the API should be considered.