### PR TITLE
Added check ttl_status

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.1"
 
 gem "sensu-json", "2.0.1"
 gem "sensu-logger", "1.2.1"
-gem "sensu-settings", "9.2.2"
+gem "sensu-settings", "9.3.0"
 gem "sensu-extension", "1.5.1"
 gem "sensu-extensions", "1.7.1"
 gem "sensu-transport", "7.0.2"

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -961,7 +961,7 @@ module Sensu
                     unless event_exists
                       check[:output] = "Last check execution was "
                       check[:output] << "#{time_since_last_execution} seconds ago"
-                      check[:status] = 1
+                      check[:status] = check[:ttl_status] || 1
                       publish_check_result(client_name, check)
                     end
                   end

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.1"
   s.add_dependency "sensu-json", "2.0.1"
   s.add_dependency "sensu-logger", "1.2.1"
-  s.add_dependency "sensu-settings", "9.2.2"
+  s.add_dependency "sensu-settings", "9.3.0"
   s.add_dependency "sensu-extension", "1.5.1"
   s.add_dependency "sensu-extensions", "1.7.1"
   s.add_dependency "sensu-transport", "7.0.2"

--- a/spec/config.json
+++ b/spec/config.json
@@ -145,7 +145,8 @@
       "command": "echo -n foobar && exit 1",
       "standalone": true,
       "interval": 1,
-      "ttl": 10
+      "ttl": 10,
+      "ttl_status": 2
     },
     "merger": {
       "command": "this will be overwritten",

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -696,14 +696,21 @@ describe "Sensu::Server::Process" do
                   result[:check][:name] = "bar"
                   result[:check][:ttl] = 60
                   transport.publish(:direct, "results", Sensu::JSON.dump(result))
+                  result[:check][:name] = "baz"
+                  result[:check][:ttl] = 30
+                  result[:check][:ttl_status] = 2
+                  transport.publish(:direct, "results", Sensu::JSON.dump(result))
                   timer(2) do
                     @server.determine_stale_check_results
                     timer(2) do
                       redis.hgetall("events:i-424242") do |events|
-                        expect(events.size).to eq(1)
+                        expect(events.size).to eq(2)
                         event = Sensu::JSON.load(events["foo"])
                         expect(event[:check][:output]).to match(/Last check execution was 3[0-9] seconds ago/)
                         expect(event[:check][:status]).to eq(1)
+                        event = Sensu::JSON.load(events["baz"])
+                        expect(event[:check][:output]).to match(/Last check execution was 3[0-9] seconds ago/)
+                        expect(event[:check][:status]).to eq(2)
                         async_done
                       end
                     end


### PR DESCRIPTION
Allows checks to set their TTL status for their associated TTL event (when they fail to produce a result in the defined number of seconds).