### PR TITLE
Configurable client deregistration check result status

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -409,11 +409,10 @@ module Sensu
       # default, the deregistration check result sets the `:handler` to
       # `deregistration`. If the client provides its own `:deregistration`
       # configuration, it's deep merged with the defaults. The
-      # check `:name`, `:output`, `:status`, `:issued`, and
-      # `:executed` values are always overridden to guard against
-      # an invalid definition.
+      # check `:name`, `:output`, `:issued`, and `:executed` values
+      # are always overridden to guard against an invalid definition.
       def deregister
-        check = {:handler => "deregistration", :interval => 1}
+        check = {:handler => "deregistration", :status => 1}
         if @settings[:client].has_key?(:deregistration)
           check = deep_merge(check, @settings[:client][:deregistration])
         end
@@ -421,7 +420,6 @@ module Sensu
         overrides = {
           :name => "deregistration",
           :output => "client initiated deregistration",
-          :status => 1,
           :issued => timestamp,
           :executed => timestamp
         }

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.1"
 
 gem "sensu-json", "2.0.1"
 gem "sensu-logger", "1.2.1"
-gem "sensu-settings", "9.3.0"
+gem "sensu-settings", "9.4.0"
 gem "sensu-extension", "1.5.1"
 gem "sensu-extensions", "1.7.1"
 gem "sensu-transport", "7.0.2"

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -71,11 +71,11 @@ module Sensu
       # default, the registration check definition sets the `:handler`
       # to `registration`. If the client provides its own
       # `:registration` configuration, it's deep merged with the
-      # defaults. The check `:name`, `:output`, `:status`, `:issued`,
-      # and `:executed` values are always overridden to guard against
-      # an invalid definition.
+      # defaults. The check `:name`, `:output`, `:issued`, and
+      # `:executed` values are always overridden to guard against an
+      # invalid definition.
       def create_registration_check(client)
-        check = {:handler => "registration"}
+        check = {:handler => "registration", :status => 1}
         if client.has_key?(:registration)
           check = deep_merge(check, client[:registration])
         end
@@ -83,7 +83,6 @@ module Sensu
         overrides = {
           :name => "registration",
           :output => "new client registration",
-          :status => 1,
           :issued => timestamp,
           :executed => timestamp
         }

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.1"
   s.add_dependency "sensu-json", "2.0.1"
   s.add_dependency "sensu-logger", "1.2.1"
-  s.add_dependency "sensu-settings", "9.3.0"
+  s.add_dependency "sensu-settings", "9.4.0"
   s.add_dependency "sensu-extension", "1.5.1"
   s.add_dependency "sensu-extensions", "1.7.1"
   s.add_dependency "sensu-transport", "7.0.2"

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -76,7 +76,6 @@ describe "Sensu::Client::Process" do
         expect(result[:check][:name]).to eq("deregistration")
         expect(result[:check][:status]).to eq(1)
         expect(result[:check][:handler]).to eq("DEREGISTER_HANDLER")
-        expect(result[:check][:interval]).to eq(1)
         async_done
       end
       timer(0.5) do


### PR DESCRIPTION
This pull request allows users to configure a per-client deregistration check result status. The default deregistration check result status is still `1` (warning). This pull request also adds the save functionality to client registration.

Example configuration:

``` json
{
  "client": {
    "...": "...",
    "deregister": true,
    "deregistration": {
      "status": 3
    }
  }
}
```