### PR TITLE
Update process.rb

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -319,7 +319,7 @@ module Sensu
       def truncate_check_output(check)
         case check[:type]
         when METRIC_CHECK_TYPE
-          output_lines = check[:output].split("\n")
+          output_lines = check[:output].encode('UTF-8', :invalid => :replace).split("\n")
           output = output_lines.first || check[:output]
           if output_lines.length > 1 || output.length > 255
             output = output[0..255] + "\n..."


### PR DESCRIPTION
had a few server panics with this error:
```
/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-0.26.5/lib/sensu/server/process.rb:322:in `split': invalid byte sequence in UTF-8 (ArgumentError)
        from /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-0.26.5/lib/sensu/server/process.rb:322:in `truncate_check_output'
        from /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-0.26.5/lib/sensu/server/process.rb:348:in `store_check_result'
        from /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-0.26.5/lib/sensu/server/process.rb:659:in `block in process_check_result'
        from /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-0.26.5/lib/sensu/server/process.rb:612:in `block in retrieve_client'
        from /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-redis-1.6.0/lib/sensu/redis/client.rb:315:in `dispatch_response'
        from /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-redis-1.6.0/lib/sensu/redis/client.rb:337:in `parse_response_line'
        from /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-redis-1.6.0/lib/sensu/redis/client.rb:365:in `receive_data'
        from /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/eventmachine-1.2.0.1/lib/eventmachine.rb:194:in `run_machine'
        from /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/eventmachine-1.2.0.1/lib/eventmachine.rb:194:in `run'
        from /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-0.26.5/lib/sensu/server/process.rb:31:in `run'
        from /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-0.26.5/exe/sensu-server:10:in `<top (required)>'
        from /opt/sensu/bin/sensu-server:22:in `load'
        from /opt/sensu/bin/sensu-server:22:in `<main>'
```

i think it comes from windows powershell check outputs, don't had the time to debug it but the server should never panic with invalid chars so this fixes it