### PR TITLE
Add type attribute to proxy clients

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -620,6 +620,7 @@ module Sensu
             end
           else
             client = create_client(client_key)
+            client[:type] = "proxy" if result[:check][:source]
             update_client_registry(client) do
               yield(client)
             end

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -535,6 +535,7 @@ describe "Sensu::Server::Process" do
                     event = Sensu::JSON.load(event_json)
                     expect(event[:client][:address]).to eq("unknown")
                     expect(event[:client][:subscriptions]).to include("client:i-888888")
+                    expect(event[:client][:type]).to eq("proxy")
                     async_done
                   end
                 end


### PR DESCRIPTION
Adds a new `type` attribute with a value of `proxy` to any clients with a `source` attribute.

## Description
To make proxy clients more distinguishable, this PR adds a new `type` attribute with a value of `proxy` to any clients with a `source` attribute. 

## Related Issue
https://github.com/sensu/sensu/issues/1532

## Motivation and Context
It makes proxy clients more distinguishable.

## How Has This Been Tested?
Specs updated to test for the existence of `client[:type] = "proxy"` on the dynamic client registration suite.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
