### PR TITLE
Added event_id to 'handler output' log msgs for pipe/extension

### DIFF
--- a/lib/sensu/server/handle.rb
+++ b/lib/sensu/server/handle.rb
@@ -29,11 +29,13 @@ module Sensu
       # @param handler [Hash] definition.
       # @param event_data [Object] provided to the spawned handler
       #   process via STDIN.
-      def pipe_handler(handler, event_data)
+      # @param event_id [String] event UUID
+      def pipe_handler(handler, event_data, event_id)
         options = {:data => event_data, :timeout => handler[:timeout]}
         Spawn.process(handler[:command], options) do |output, status|
           @logger.info("handler output", {
             :handler => handler,
+            :event => { :id => event_id },
             :output => output.split("\n+")
           })
           @in_progress[:events] -= 1 if @in_progress
@@ -116,10 +118,12 @@ module Sensu
       #
       # @param handler [Hash] definition.
       # @param event_data [Object] to pass to the handler extension.
-      def handler_extension(handler, event_data)
+      # @param event_id [String] event UUID
+      def handler_extension(handler, event_data, event_id)
         handler.safe_run(event_data) do |output, status|
           @logger.info("handler extension output", {
             :extension => handler.definition,
+            :event => { :id => event_id },
             :output => output,
             :status => status
           })
@@ -132,10 +136,11 @@ module Sensu
       #
       # @param handler [Hash] definition.
       # @param event_data [Object] to pass to the handler type method.
-      def handler_type_router(handler, event_data)
+      # @param event_id [String] event UUID
+      def handler_type_router(handler, event_data, event_id)
         case handler[:type]
         when "pipe"
-          pipe_handler(handler, event_data)
+          pipe_handler(handler, event_data, event_id)
         when "tcp"
           tcp_handler(handler, event_data)
         when "udp"
@@ -143,7 +148,7 @@ module Sensu
         when "transport"
           transport_handler(handler, event_data)
         when "extension"
-          handler_extension(handler, event_data)
+          handler_extension(handler, event_data, event_id)
         end
       end
 
@@ -154,13 +159,15 @@ module Sensu
       #
       # @param handler [Hash] definition.
       # @param event_data [Object] to pass to an event handler.
-      def handle_event(handler, event_data)
+      # @param event_id [String] event UUID
+      def handle_event(handler, event_data, event_id)
         definition = handler.is_a?(Hash) ? handler : handler.definition
         @logger.debug("handling event", {
           :event_data => event_data,
+          :event => { :id => event_id },
           :handler => definition
         })
-        handler_type_router(handler, event_data)
+        handler_type_router(handler, event_data, event_id)
       end
     end
   end

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -251,7 +251,7 @@ module Sensu
           @in_progress[:events] += 1
           filter_event(handler, event) do |event|
             mutate_event(handler, event) do |event_data|
-              handle_event(handler, event_data)
+              handle_event(handler, event_data, event[:id])
             end
           end
         end

--- a/spec/server/handle_spec.rb
+++ b/spec/server/handle_spec.rb
@@ -9,6 +9,7 @@ describe "Sensu::Server::Handle" do
     @server = Sensu::Server::Process.new(options)
     settings = Sensu::Settings.get(options)
     @handlers = settings[:handlers]
+    @event_id  = event_template[:id]
     @event_data = Sensu::JSON.dump(event_template)
     @extensions = Sensu::Extensions.get(options)
   end
@@ -20,7 +21,7 @@ describe "Sensu::Server::Handle" do
 
   it "can handle an event with a pipe handler" do
     async_wrapper do
-      @server.handle_event(@handlers[:file], @event_data)
+      @server.handle_event(@handlers[:file], @event_data, @event_id)
       timer(1) do
         async_done
       end
@@ -34,7 +35,7 @@ describe "Sensu::Server::Handle" do
       EM::start_server("127.0.0.1", 1234, Helpers::TestServer) do |server|
         server.expected = @event_data
       end
-      @server.handle_event(@handlers[:tcp], @event_data)
+      @server.handle_event(@handlers[:tcp], @event_data, @event_id)
     end
   end
 
@@ -43,7 +44,7 @@ describe "Sensu::Server::Handle" do
       EM::open_datagram_socket("127.0.0.1", 1234, Helpers::TestServer) do |server|
         server.expected = @event_data
       end
-      @server.handle_event(@handlers[:udp], @event_data)
+      @server.handle_event(@handlers[:udp], @event_data, @event_id)
     end
   end
 
@@ -57,7 +58,7 @@ describe "Sensu::Server::Handle" do
       end
       timer(0.5) do
         @server.setup_transport do
-          @server.handle_event(@handlers[:transport], @event_data)
+          @server.handle_event(@handlers[:transport], @event_data, @event_id)
         end
       end
     end
@@ -65,7 +66,7 @@ describe "Sensu::Server::Handle" do
 
   it "can handle an event with an extension" do
     async_wrapper do
-      @server.handle_event(@extensions[:handlers]["debug"], @event_data)
+      @server.handle_event(@extensions[:handlers]["debug"], @event_data, @event_id)
       timer(0.5) do
         async_done
       end


### PR DESCRIPTION
## Description

This PR contains changes from #919 by @withnale, rebased on current master. The idea here is to make the event ID explicitly available to handlers for logging purposes.

## Related Issue

Closes #919.

## Motivation and Context

Because a Sensu mutator may be used to modify event data before it is passed to a handler, handlers cannot always depend on the event ID being included when receiving event data via STDIN. Explicitly passing the event ID as an argument enables log messages to provide context connecting handler log messages to the event triggering the handler.

## How Has This Been Tested?

Unit tests have been updated and are passing. Unit tests do not cover the content of log messages.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (yardoc)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
