### PR TITLE
[server/filter] fix null filter name in event_filtered?

### DIFF
--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -264,7 +264,7 @@ module Sensu
               yield(false)
             else
               event_filter(filter_name, event) do |filtered|
-                filtered ? yield(true) : EM.next_tick { filter.call(filter_list) }
+                filtered ? yield(true, filter_name) : EM.next_tick { filter.call(filter_list) }
               end
             end
           end

--- a/spec/server/filter_spec.rb
+++ b/spec/server/filter_spec.rb
@@ -99,8 +99,9 @@ describe "Sensu::Server::Filter" do
             handler = {
               :filter => "development"
             }
-            @server.event_filtered?(handler, @event) do |filtered|
+            @server.event_filtered?(handler, @event) do |filtered, filter_name|
               expect(filtered).to be(true)
+              expect(filter_name).to eq("development")
               handler = {
                 :filters => ["production"]
               }


### PR DESCRIPTION
## Description

Ensure filter name is returned when event is filtered by `Sensu::Server::Filter#event_filtered?`

## Related Issue

Closes #1546

## Motivation and Context

Ensure feature implemented in https://github.com/sensu/sensu/pull/1467 works as intended.

## How Has This Been Tested?

Extended unit tests to better cover this case, test implementation in lab environment.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
