### PR TITLE
[server/update-client-registry] add per-client sub if missing

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -142,9 +142,7 @@ module Sensu
       def update_client_registry(client)
         @logger.debug("updating client registry", :client => client)
         client_key = "client:#{client[:name]}"
-        client[:subscriptions] = [
-          client[:subscriptions], [client_key]
-        ].compact.flatten.uniq
+        client[:subscriptions] = (client[:subscriptions] + [client_key]).uniq
         signature_key = "#{client_key}:signature"
         @redis.setnx(signature_key, client[:signature]) do |created|
           process_client_registration(client) if created

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -47,7 +47,12 @@ describe "Sensu::Server::Process" do
                 expect(exists).to be(true)
                 redis.get("client:i-424242") do |client_json|
                   client = Sensu::JSON.load(client_json)
-                  expect(client).to eq(keepalive)
+                  # keepalive processing adds a per-client subscription
+                  processed_keepalive = keepalive.dup
+                  processed_keepalive[:subscriptions] = [
+                    keepalive[:subscriptions], ["client:#{keepalive[:name]}"]
+                  ].compact.flatten.uniq
+                  expect(client).to eq(processed_keepalive)
                   read_event_file = Proc.new do
                     begin
                       event_file = IO.read("/tmp/sensu_client_registration.json")
@@ -58,7 +63,7 @@ describe "Sensu::Server::Process" do
                   end
                   compare_event_file = Proc.new do |event_file|
                     expect(event_file[:check][:name]).to eq("registration")
-                    expect(event_file[:client]).to eq(keepalive)
+                    expect(event_file[:client]).to eq(processed_keepalive)
                     async_done
                   end
                   EM.defer(read_event_file, compare_event_file)
@@ -78,6 +83,11 @@ describe "Sensu::Server::Process" do
         keepalive = client_template
         keepalive[:timestamp] = epoch
         keepalive[:signature] = "foo"
+        # keepalive processing adds a per-client subscription
+        processed_keepalive = keepalive.dup
+        processed_keepalive[:subscriptions] = [
+          keepalive[:subscriptions], ["client:#{keepalive[:name]}"]
+        ].compact.flatten.uniq
         redis.flushdb do
           timer(1) do
             setup_transport do |transport|
@@ -85,7 +95,7 @@ describe "Sensu::Server::Process" do
               timer(1) do
                 redis.get("client:i-424242") do |client_json|
                   client = Sensu::JSON.load(client_json)
-                  expect(client).to eq(keepalive)
+                  expect(client).to eq(processed_keepalive)
                   redis.get("client:i-424242:signature") do |signature|
                     expect(signature).to eq("foo")
                     malicious = keepalive.dup
@@ -95,7 +105,7 @@ describe "Sensu::Server::Process" do
                     timer(1) do
                       redis.get("client:i-424242") do |client_json|
                         client = Sensu::JSON.load(client_json)
-                        expect(client).to eq(keepalive)
+                        expect(client).to eq(processed_keepalive)
                         redis.get("client:i-424242:signature") do |signature|
                           expect(signature).to eq("foo")
                           async_done

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -49,9 +49,9 @@ describe "Sensu::Server::Process" do
                   client = Sensu::JSON.load(client_json)
                   # keepalive processing adds a per-client subscription
                   processed_keepalive = keepalive.dup
-                  processed_keepalive[:subscriptions] = [
-                    keepalive[:subscriptions], ["client:#{keepalive[:name]}"]
-                  ].compact.flatten.uniq
+                  processed_keepalive[:subscriptions] = (
+                    keepalive[:subscriptions] + ["client:#{keepalive[:name]}"]
+                  ).uniq
                   expect(client).to eq(processed_keepalive)
                   read_event_file = Proc.new do
                     begin
@@ -85,9 +85,9 @@ describe "Sensu::Server::Process" do
         keepalive[:signature] = "foo"
         # keepalive processing adds a per-client subscription
         processed_keepalive = keepalive.dup
-        processed_keepalive[:subscriptions] = [
-          keepalive[:subscriptions], ["client:#{keepalive[:name]}"]
-        ].compact.flatten.uniq
+        processed_keepalive[:subscriptions] = (
+          keepalive[:subscriptions] + ["client:#{keepalive[:name]}"]
+        ).uniq
         redis.flushdb do
           timer(1) do
             setup_transport do |transport|


### PR DESCRIPTION
## Description

This change ensures that per-client subscriptions are included when updating entries in the client registrry.

## Related Issue

Closes #1545 

## Motivation and Context

Native silencing, added in Sensu 0.26, requires clients to have a [per-client subscription]() in order for silencing to be effective for individual clients. Although Sensu client adds this subscription automatically as of 0.26, older clients currently require a configuration change to add this subscription.

This change makes addition of the per-client subscription automatic on the server side, which I believe will ensure native silencing is fully backward compatible with older versions of the Sensu client.

## How Has This Been Tested?

Updated unit tests to reflect added per-client subscription.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
