### PR TITLE
[server/handle] use pipe handler status to set log level

### DIFF
--- a/lib/sensu/server/handle.rb
+++ b/lib/sensu/server/handle.rb
@@ -38,8 +38,8 @@ module Sensu
         Spawn.process(handler[:command], options) do |output, status|
           log_level = status == 0 ? :info : :error
           @logger.send(log_level, "handler output", {
-              :handler => handler,
-              :output => output.split("\n+")
+             :handler => handler,
+             :output => output.split("\n+")
             })
           @in_progress[:events] -= 1 if @in_progress
         end

--- a/lib/sensu/server/handle.rb
+++ b/lib/sensu/server/handle.rb
@@ -38,9 +38,9 @@ module Sensu
         Spawn.process(handler[:command], options) do |output, status|
           log_level = status == 0 ? :info : :error
           @logger.send(log_level, "handler output", {
-             :handler => handler,
-             :output => output.split("\n+")
-            })
+            :handler => handler,
+            :output => output.split("\n+")
+          })
           @in_progress[:events] -= 1 if @in_progress
         end
       end

--- a/lib/sensu/server/handle.rb
+++ b/lib/sensu/server/handle.rb
@@ -26,16 +26,21 @@ module Sensu
       # `@in_progress[:events]` by `1` when the handler executes
       # successfully.
       #
+      # When the spawned process exits with status 0, its output is
+      # logged at :info level. Otherwise, its output is logged at
+      # :error level.
+      #
       # @param handler [Hash] definition.
       # @param event_data [Object] provided to the spawned handler
       #   process via STDIN.
       def pipe_handler(handler, event_data)
         options = {:data => event_data, :timeout => handler[:timeout]}
         Spawn.process(handler[:command], options) do |output, status|
-          @logger.info("handler output", {
-            :handler => handler,
-            :output => output.split("\n+")
-          })
+          log_level = status == 0 ? :info : :error
+          @logger.send(log_level, "handler output", {
+              :handler => handler,
+              :output => output.split("\n+")
+            })
           @in_progress[:events] -= 1 if @in_progress
         end
       end

--- a/spec/config.json
+++ b/spec/config.json
@@ -71,6 +71,10 @@
       "type": "pipe",
       "command": "cat > /tmp/sensu_event"
     },
+    "error": {
+      "type": "pipe",
+      "command": "cat && exit 2"
+    },
     "filtered": {
       "type": "pipe",
       "command": "cat > /tmp/sensu_event",

--- a/spec/server/handle_spec.rb
+++ b/spec/server/handle_spec.rb
@@ -29,6 +29,15 @@ describe "Sensu::Server::Handle" do
     File.delete("/tmp/sensu_event")
   end
 
+  it "can handle an event with a pipe handler error" do
+    async_wrapper do
+      @server.handle_event(@handlers[:error], @event_data)
+      timer(1) do
+        async_done
+      end
+    end
+  end
+
   it "can handle an event with a tcp handler" do
     async_wrapper do
       EM::start_server("127.0.0.1", 1234, Helpers::TestServer) do |server|


### PR DESCRIPTION
## Description

This change uses the exit status of a pipe handler to determine the level at which that handler's output should be logged. Handler output is logged at the `info` level when the exit status is 0, otherwise the output is logged at the `error` level.

## Related Issue

Closes #1542 

## Motivation and Context

Logging handler errors at `info` level can make it harder to discover handler errors in server logs.

## How Has This Been Tested?

Added spec for a handler exiting with a non-zero status.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
