### PR TITLE
Enable EventMachine epoll when available & use EventMachine 1.2.2

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -1,6 +1,6 @@
 require "rubygems"
 
-gem "eventmachine", "1.2.1"
+gem "eventmachine", "1.2.2"
 
 gem "sensu-json", "2.0.1"
 gem "sensu-logger", "1.2.1"
@@ -48,7 +48,10 @@ module Sensu
       @start_time = Time.now.to_i
       @state = :initializing
       @timers = {:run => []}
-      EM::set_max_timers(200000) unless EM::reactor_running?
+      unless EM::reactor_running?
+        EM::epoll
+        EM::set_max_timers(200000)
+      end
       setup_logger(options)
       load_settings(options)
       unless sensu_service_name == "api"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.has_rdoc    = false
 
-  s.add_dependency "eventmachine", "1.2.1"
+  s.add_dependency "eventmachine", "1.2.2"
   s.add_dependency "sensu-json", "2.0.1"
   s.add_dependency "sensu-logger", "1.2.1"
   s.add_dependency "sensu-settings", "9.6.0"


### PR DESCRIPTION
Enabling EM epoll should close https://github.com/sensu/sensu/issues/1560

EventMachine 1.2.2 has several fixes: https://github.com/eventmachine/eventmachine/blob/master/CHANGELOG.md#122-january-23-2017