### PR TITLE
Schedule checks with cron syntax

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -294,8 +294,8 @@ module Sensu
       #
       # @param check [Hash] definition.
       def schedule_check_cron_execution(check)
-        cron_timer = determine_check_cron_timer(check)
-        @timers[:run] << EM::Timer.new(cron_timer) do |timer|
+        cron_time = determine_check_cron_time(check)
+        @timers[:run] << EM::Timer.new(cron_time) do |timer|
           create_check_execution_proc(check).call
           @timers[:run].delete(timer)
           schedule_check_cron_execution(check)

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.1"
 
 gem "sensu-json", "2.0.1"
 gem "sensu-logger", "1.2.1"
-gem "sensu-settings", "9.7.0"
+gem "sensu-settings", "9.9.0"
 gem "sensu-extension", "1.5.1"
 gem "sensu-extensions", "1.7.1"
 gem "sensu-transport", "7.0.2"

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -837,8 +837,8 @@ module Sensu
       #
       # @param check [Hash] definition.
       def schedule_check_cron_request(check)
-        cron_timer = determine_check_cron_timer(check)
-        @timers[:leader] << EM::Timer.new(cron_timer) do |timer|
+        cron_time = determine_check_cron_time(check)
+        @timers[:leader] << EM::Timer.new(cron_time) do |timer|
           create_check_request_proc(check).call
           @timers[:leader].delete(timer)
           schedule_check_cron_request(check)

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -803,6 +803,13 @@ module Sensu
         end
       end
 
+      # Create a check request proc, used to publish check requests to
+      # for a check to the Sensu transport. Check requests are not
+      # published if subdued. This method determines if a check uses
+      # proxy check requests and calls the appropriate check request
+      # publish method.
+      #
+      # @param check [Hash] definition.
       def create_check_request_proc(check)
         Proc.new do
           unless check_subdued?(check)
@@ -817,49 +824,66 @@ module Sensu
         end
       end
 
-      def create_check_cron_execution(check)
+      # Schedule a check request, using the check cron. This method
+      # determines the time until the next cron time (in seconds) and
+      # creats an EventMachine timer for the request. This method will
+      # be called after every check cron request for subsequent
+      # requests. The timer is stored in the timer hash under
+      # `:leader`, as check request publishing is a task for only the
+      # Sensu server leader, so they can be cancelled etc. The check
+      # cron request timer object in the timer hash under `:leader` is
+      # deleted after publishing the check request.
+      #
+      # @param check [Hash] definition.
+      def schedule_check_cron_request(check)
         cron_timer = determine_check_cron_timer(check)
         @timers[:leader] << EM::Timer.new(cron_timer) do |timer|
           create_check_request_proc(check).call
           @timers[:leader].delete(timer)
-          create_check_cron_execution(check)
+          schedule_check_cron_request(check)
         end
       end
 
-      # Calculate a check execution splay, taking into account the
-      # current time and the execution interval to ensure it's
+      # Calculate a check request splay, taking into account the
+      # current time and the request interval to ensure it's
       # consistent between process restarts.
       #
       # @param check [Hash] definition.
-      def calculate_check_execution_splay(check)
+      def calculate_check_request_splay(check)
         splay_hash = Digest::MD5.digest(check[:name]).unpack('Q<').first
         current_time = (Time.now.to_f * 1000).to_i
         (splay_hash - current_time) % (check[:interval] * 1000) / 1000.0
       end
 
-      def create_check_executions(check)
-        execution_splay = testing? ? 0 : calculate_check_execution_splay(check)
+      # Schedule check requests, using the check interval. This method
+      # using an intial calculated request splay EventMachine timer
+      # and an EventMachine periodic timer for subsequent check
+      # requests. The timers are stored in the timers hash under
+      # `:leader`, as check request publishing is a task for only the
+      # Sensu server leader, so they can be cancelled etc.
+      #
+      # @param check [Hash] definition.
+      def schedule_check_interval_requests(check)
+        request_splay = testing? ? 0 : calculate_check_request_splay(check)
         interval = testing? ? 0.5 : check[:interval]
-        @timers[:leader] << EM::Timer.new(execution_splay) do
+        @timers[:leader] << EM::Timer.new(request_splay) do
           create_check_request = create_check_request_proc(check)
           create_check_request.call
           @timers[:leader] << EM::PeriodicTimer.new(interval, &create_check_request)
         end
       end
 
-      # Schedule check executions, using EventMachine periodic timers,
-      # using a calculated execution splay. The timers are stored in
-      # the timers hash under `:leader`, as check request publishing
-      # is a task for only the Sensu server leader, so they can be
-      # cancelled etc. Check requests are not published if subdued.
+      # Schedule check requests. This method iterates through defined
+      # checks and uses the appropriate method of check request
+      # scheduling, either with the cron syntax or numeric interval.
       #
       # @param checks [Array] of definitions.
       def schedule_checks(checks)
         checks.each do |check|
           if check[:cron]
-            create_check_cron_execution(check)
+            schedule_check_cron_request(check)
           else
-            create_check_executions(check)
+            schedule_check_interval_requests(check)
           end
         end
       end

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -830,9 +830,10 @@ module Sensu
       # be called after every check cron request for subsequent
       # requests. The timer is stored in the timer hash under
       # `:leader`, as check request publishing is a task for only the
-      # Sensu server leader, so they can be cancelled etc. The check
-      # cron request timer object in the timer hash under `:leader` is
-      # deleted after publishing the check request.
+      # Sensu server leader, so it can be cancelled etc. The check
+      # cron request timer object is removed from the timer hash after
+      # the request is published, to stop the timer hash from growing
+      # infinitely.
       #
       # @param check [Hash] definition.
       def schedule_check_cron_request(check)
@@ -875,7 +876,7 @@ module Sensu
 
       # Schedule check requests. This method iterates through defined
       # checks and uses the appropriate method of check request
-      # scheduling, either with the cron syntax or numeric interval.
+      # scheduling, either with the cron syntax or a numeric interval.
       #
       # @param checks [Array] of definitions.
       def schedule_checks(checks)
@@ -890,19 +891,14 @@ module Sensu
 
       # Set up the check request publisher. This method creates an
       # array of check definitions, that are not standalone checks,
-      # and do not have `:publish` set to `false`. The array of check
-      # definitions includes those from standard checks and extensions
-      # (with a defined execution `:interval`). The array is provided
-      # to the `schedule_check_executions()` method.
+      # and do not have `:publish` set to `false`. The array is
+      # provided to the `schedule_checks()` method.
       def setup_check_request_publisher
         @logger.debug("scheduling check requests")
-        standard_checks = @settings.checks.reject do |check|
+        checks = @settings.checks.reject do |check|
           check[:standalone] || check[:publish] == false
         end
-        extension_checks = @extensions.checks.reject do |check|
-          check[:standalone] || check[:publish] == false || !check[:interval].is_a?(Integer)
-        end
-        schedule_checks(standard_checks + extension_checks)
+        schedule_checks(checks)
       end
 
       # Publish a check result to the Transport for processing. A

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -803,6 +803,29 @@ module Sensu
         end
       end
 
+      def create_check_request_proc(check)
+        Proc.new do
+          unless check_subdued?(check)
+            if check[:proxy_requests]
+              publish_proxy_check_requests(check)
+            else
+              publish_check_request(check)
+            end
+          else
+            @logger.info("check request was subdued", :check => check)
+          end
+        end
+      end
+
+      def create_check_cron_execution(check)
+        cron_timer = determine_check_cron_timer(check)
+        @timers[:leader] << EM::Timer.new(cron_timer) do |timer|
+          create_check_request_proc(check).call
+          @timers[:leader].delete(timer)
+          create_check_cron_execution(check)
+        end
+      end
+
       # Calculate a check execution splay, taking into account the
       # current time and the execution interval to ensure it's
       # consistent between process restarts.
@@ -814,6 +837,16 @@ module Sensu
         (splay_hash - current_time) % (check[:interval] * 1000) / 1000.0
       end
 
+      def create_check_executions(check)
+        execution_splay = testing? ? 0 : calculate_check_execution_splay(check)
+        interval = testing? ? 0.5 : check[:interval]
+        @timers[:leader] << EM::Timer.new(execution_splay) do
+          create_check_request = create_check_request_proc(check)
+          create_check_request.call
+          @timers[:leader] << EM::PeriodicTimer.new(interval, &create_check_request)
+        end
+      end
+
       # Schedule check executions, using EventMachine periodic timers,
       # using a calculated execution splay. The timers are stored in
       # the timers hash under `:leader`, as check request publishing
@@ -823,22 +856,10 @@ module Sensu
       # @param checks [Array] of definitions.
       def schedule_check_executions(checks)
         checks.each do |check|
-          create_check_request = Proc.new do
-            unless check_subdued?(check)
-              if check[:proxy_requests]
-                publish_proxy_check_requests(check)
-              else
-                publish_check_request(check)
-              end
-            else
-              @logger.info("check request was subdued", :check => check)
-            end
-          end
-          execution_splay = testing? ? 0 : calculate_check_execution_splay(check)
-          interval = testing? ? 0.5 : check[:interval]
-          @timers[:leader] << EM::Timer.new(execution_splay) do
-            create_check_request.call
-            @timers[:leader] << EM::PeriodicTimer.new(interval, &create_check_request)
+          if check[:cron]
+            create_check_cron_execution(check)
+          else
+            create_check_executions(check)
           end
         end
       end

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -854,7 +854,7 @@ module Sensu
       # cancelled etc. Check requests are not published if subdued.
       #
       # @param checks [Array] of definitions.
-      def schedule_check_executions(checks)
+      def schedule_checks(checks)
         checks.each do |check|
           if check[:cron]
             create_check_cron_execution(check)
@@ -878,7 +878,7 @@ module Sensu
         extension_checks = @extensions.checks.reject do |check|
           check[:standalone] || check[:publish] == false || !check[:interval].is_a?(Integer)
         end
-        schedule_check_executions(standard_checks + extension_checks)
+        schedule_checks(standard_checks + extension_checks)
       end
 
       # Publish a check result to the Transport for processing. A

--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -1,5 +1,8 @@
+gem "parse-cron", "0.1.4"
+
 require "securerandom"
 require "sensu/sandbox"
+require "parse-cron"
 
 module Sensu
   module Utilities

--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -306,5 +306,12 @@ module Sensu
         false
       end
     end
+
+    def determine_check_cron_timer(check)
+      cron_parser = CronParser.new(check[:cron])
+      current_time = Time.now
+      next_cron_time = cron_parser.next(current_time)
+      next_cron_time - current_time
+    end
   end
 end

--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -307,7 +307,10 @@ module Sensu
       end
     end
 
-    def determine_check_cron_timer(check)
+    # Determine the next check cron time.
+    #
+    # @param check [Hash] definition.
+    def determine_check_cron_time(check)
       cron_parser = CronParser.new(check[:cron])
       current_time = Time.now
       next_cron_time = cron_parser.next(current_time)

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sensu-spawn", "2.2.1"
   s.add_dependency "sensu-redis", "2.1.0"
   s.add_dependency "em-http-server", "0.1.8"
+  s.add_dependency "parse-cron", "0.1.4"
 
   s.add_development_dependency "rake", "10.5.0"
   s.add_development_dependency "rspec", "~> 3.0.0"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.1"
   s.add_dependency "sensu-json", "2.0.1"
   s.add_dependency "sensu-logger", "1.2.1"
-  s.add_dependency "sensu-settings", "9.7.0"
+  s.add_dependency "sensu-settings", "9.9.0"
   s.add_dependency "sensu-extension", "1.5.1"
   s.add_dependency "sensu-extensions", "1.7.1"
   s.add_dependency "sensu-transport", "7.0.2"

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -313,9 +313,9 @@ describe "Sensu::Client::Process" do
     allow(Time).to receive(:now).and_return("1414213569.032")
     check = check_template
     check[:interval] = 60
-    expect(@client.calculate_execution_splay(check)).to eq(3.321)
+    expect(@client.calculate_check_execution_splay(check)).to eq(3.321)
     check[:interval] = 3600
-    expect(@client.calculate_execution_splay(check)).to eq(783.321)
+    expect(@client.calculate_check_execution_splay(check)).to eq(783.321)
   end
 
   it "can accept external result input via sockets" do

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -277,6 +277,16 @@ describe "Sensu::Client::Process" do
     end
   end
 
+  it "can schedule standalone check execution using the cron syntax" do
+    async_wrapper do
+      check = check_template
+      check[:cron] = "* * * * *"
+      @client.schedule_checks([check])
+      expect(@client.instance_variable_get(:@timers)[:run].size).to eq(1)
+      async_done
+    end
+  end
+
   it "can subdue standalone check execution" do
     async_wrapper do
       result_queue do |payload|

--- a/spec/config.json
+++ b/spec/config.json
@@ -179,8 +179,7 @@
       "subscribers": [
         "test"
       ],
-      "cron": "* * * * *",
-      "interval": 1
+      "cron": "* * * * *"
     }
   },
   "client": {

--- a/spec/config.json
+++ b/spec/config.json
@@ -173,6 +173,14 @@
       "subscribers": [
         "test"
       ]
+    },
+    "cron": {
+      "command": "/bin/true",
+      "subscribers": [
+        "test"
+      ],
+      "cron": "* * * * *",
+      "interval": 1
     }
   },
   "client": {

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -667,13 +667,13 @@ describe "Sensu::Server::Process" do
 
   it "can schedule check request publishing" do
     async_wrapper do
-      expected = ["tokens", "merger", "sensu_cpu_time", "source"]
+      expected = ["tokens", "merger", "source", "cron"]
       setup_transport do |transport|
         transport.subscribe(:fanout, "test") do |_, payload|
           check_request = Sensu::JSON.load(payload)
           expect(check_request[:issued]).to be_within(10).of(epoch)
           expect(expected.delete(check_request[:name])).not_to be_nil
-          async_done if expected.empty?
+          async_done if expected.empty? || expected == ["cron"]
         end
       end
       timer(0.5) do

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -684,6 +684,16 @@ describe "Sensu::Server::Process" do
     end
   end
 
+  it "can schedule check request publishing using the cron syntax" do
+    async_wrapper do
+      check = check_template
+      check[:cron] = "* * * * *"
+      @server.schedule_checks([check])
+      expect(@server.instance_variable_get(:@timers)[:leader].size).to eq(1)
+      async_done
+    end
+  end
+
   it "can send a check result" do
     async_wrapper do
       result_queue do |payload|

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -656,13 +656,13 @@ describe "Sensu::Server::Process" do
     end
   end
 
-  it "can calculate a check execution splay interval" do
+  it "can calculate a check request splay interval" do
     allow(Time).to receive(:now).and_return("1414213569.032")
     check = check_template
     check[:interval] = 60
-    expect(@server.calculate_check_execution_splay(check)).to eq(17.601)
+    expect(@server.calculate_check_request_splay(check)).to eq(17.601)
     check[:interval] = 3600
-    expect(@server.calculate_check_execution_splay(check)).to eq(3497.601)
+    expect(@server.calculate_check_request_splay(check)).to eq(3497.601)
   end
 
   it "can schedule check request publishing" do


### PR DESCRIPTION
## Description

This pull requests adds support for scheduling check requests and standalone execution with the [cron syntax](https://en.wikipedia.org/wiki/Cron).

```json
{
  "checks": {
    "cron": {
      "command": "/bin/true",
      "subscribers": [
        "test"
      ],
      "cron": "* * * * *"
    }
  }
}
```

## Related Issue

This pull request is based off of the work done by chriszacny on https://github.com/sensu/sensu/pull/1397, which served as a great feature request and implementation example. I have tried to use all of the feedback provided.

## Motivation and Context

Schedule checks to run at specific times, not just on an interval.

## How Has This Been Tested?

RSpec & manual testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
