### PR TITLE
API POST /request optional reason and creator

### DIFF
--- a/lib/sensu/api/routes/request.rb
+++ b/lib/sensu/api/routes/request.rb
@@ -12,7 +12,9 @@ module Sensu
         def post_request
           rules = {
             :check => {:type => String, :nil_ok => false},
-            :subscribers => {:type => Array, :nil_ok => true}
+            :subscribers => {:type => Array, :nil_ok => true},
+            :reason => {:type => String, :nil_ok => true},
+            :creator => {:type => String, :nil_ok => true}
           }
           read_data(rules) do |data|
             if @settings[:checks][data[:check]]
@@ -20,6 +22,10 @@ module Sensu
               check[:name] = data[:check]
               check[:subscribers] ||= Array.new
               check[:subscribers] = data[:subscribers] if data[:subscribers]
+              check[:api_requested] = {
+                :reason => data[:reason],
+                :creator => data[:creator]
+              }
               publish_check_request(check)
               @response_content = {:issued => Time.now.to_i}
               accepted!

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -587,6 +587,28 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can issue a check request with a reason and creator" do
+    api_test do
+      options = {
+        :body => {
+          :check => "tokens",
+          :subscribers => [
+            "test",
+            "roundrobin:rspec",
+            1
+          ],
+          :reason => "post deploy validation",
+          :creator => "rspec"
+        }
+      }
+      http_request(4567, "/request", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(202)
+        expect(body).to include(:issued)
+        async_done
+      end
+    end
+  end
+
   it "can not issue a check request with an invalid post body" do
     api_test do
       options = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull request adds `reason` and `creator` to API POST /request JSON body attributes, inline with those used for silence entries.

Example check request published by the API:

```
{"timestamp":"2017-02-22T15:09:45.906639-0800","level":"info","message":"received check request","check":{"command":"/bin/true","publish":false,"subscribers":["test"],"name":"unpublished","api_requested":{"reason":"foobar","creator":"portertech"},"issued":1487804985}}
{"timestamp":"2017-02-22T15:09:45.906726-0800","level":"debug","message":"processing check","check":{"command":"/bin/true","publish":false,"subscribers":["test"],"name":"unpublished","api_requested":{"reason":"foobar","creator":"portertech"},"issued":1487804985}}
{"timestamp":"2017-02-22T15:09:45.906770-0800","level":"debug","message":"attempting to execute check command","check":{"command":"/bin/true","publish":false,"subscribers":["test"],"name":"unpublished","api_requested":{"reason":"foobar","creator":"portertech"},"issued":1487804985}}
{"timestamp":"2017-02-22T15:09:45.916515-0800","level":"info","message":"publishing check result","payload":{"client":"i-424242","check":{"command":"/bin/true","publish":false,"subscribers":["test"],"name":"unpublished","api_requested":{"reason":"foobar","creator":"portertech"},"issued":1487804985,"executed":1487804985,"duration":0.01,"output":"","status":0}}}
```

## Related Issue

https://github.com/sensu/sensu/issues/1469

## How Has This Been Tested?

RSpec and manual testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
