### PR TITLE
Proxy switch for sensu-install

### DIFF
--- a/exe/sensu-install
+++ b/exe/sensu-install
@@ -10,7 +10,8 @@ module Sensu
           :verbose => false,
           :plugins => [],
           :extensions => [],
-          :clean => false
+          :clean => false,
+          :proxy => ""
         }
         optparse = OptionParser.new do |opts|
           opts.on("-h", "--help", "Display this message") do
@@ -37,6 +38,9 @@ module Sensu
           end
           opts.on("-c", "--clean", "Clean up (remove) other installed versions of the plugin(s) and/or extension(s)") do
             options[:clean] = true
+          end
+          opts.on("-x", "--proxy PROXY", "Install plugins via a PROXY url") do |proxy|
+            options[:proxy] << proxy
           end
         end
         optparse.parse!(arguments)
@@ -70,6 +74,7 @@ module Sensu
         gem_command << " --no-ri --no-rdoc"
         gem_command << " --verbose" if options[:verbose]
         gem_command << " --source #{options[:source]}" if options[:source]
+        gem_command << " --http-proxy #{options[:proxy]}"
         log gem_command if options[:verbose]
         unless system(gem_command)
           log "failed to install Sensu gem '#{gem_name}'"

--- a/exe/sensu-install
+++ b/exe/sensu-install
@@ -39,7 +39,7 @@ module Sensu
           opts.on("-c", "--clean", "Clean up (remove) other installed versions of the plugin(s) and/or extension(s)") do
             options[:clean] = true
           end
-          opts.on("-x", "--proxy PROXY", "Install plugins via a PROXY url") do |proxy|
+          opts.on("-x", "--proxy PROXY", "Install Sensu plugins and extensions via a PROXY URL") do |proxy|
             options[:proxy] = proxy
           end
         end

--- a/exe/sensu-install
+++ b/exe/sensu-install
@@ -11,7 +11,7 @@ module Sensu
           :plugins => [],
           :extensions => [],
           :clean => false,
-          :proxy => ""
+          :proxy => nil
         }
         optparse = OptionParser.new do |opts|
           opts.on("-h", "--help", "Display this message") do
@@ -40,7 +40,7 @@ module Sensu
             options[:clean] = true
           end
           opts.on("-x", "--proxy PROXY", "Install plugins via a PROXY url") do |proxy|
-            options[:proxy] << proxy
+            options[:proxy] = proxy
           end
         end
         optparse.parse!(arguments)
@@ -74,7 +74,7 @@ module Sensu
         gem_command << " --no-ri --no-rdoc"
         gem_command << " --verbose" if options[:verbose]
         gem_command << " --source #{options[:source]}" if options[:source]
-        gem_command << " --http-proxy #{options[:proxy]}"
+        gem_command << " --http-proxy #{options[:proxy]}" if options[:proxy]
         log gem_command if options[:verbose]
         unless system(gem_command)
           log "failed to install Sensu gem '#{gem_name}'"


### PR DESCRIPTION
Added in support to utilize the proxy option for `gem`.

## Description
The sensu-install utility was unable to install the sensu plugins via a proxy server. This rectifies that issue.

## Related Issue
https://github.com/sensu/sensu/issues/1588

## Motivation and Context
Allows the use of proxy servers for sensu-install.

## How Has This Been Tested?
This was tested against two RHEL 7 servers.

1. A server behind a proxy, without direct access to the internet. Installations failed before, they work with the proposed changes.
2. A server with direct access to the internet, without providing any options to the proxy variable. This worked as expected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
