### PR TITLE
API response content filtering

### DIFF
--- a/lib/sensu/api/http_handler.rb
+++ b/lib/sensu/api/http_handler.rb
@@ -175,9 +175,10 @@ module Sensu
       # Respond to an HTTP request. The routes set `@response_status`,
       # `@response_status_string`, and `@response_content`
       # appropriately. The HTTP response status defaults to `200` with
-      # the status string `OK`. The Sensu API only returns JSON
-      # response content, `@response_content` is assumed to be a Ruby
-      # object that can be serialized as JSON.
+      # the status string `OK`. If filter params were provided,
+      # `@response_content` is filtered (mutated). The Sensu API only
+      # returns JSON response content, `@response_content` is assumed
+      # to be a Ruby object that can be serialized as JSON.
       def respond
         @response.status = @response_status || 200
         @response.status_string = @response_status_string || "OK"

--- a/lib/sensu/api/http_handler.rb
+++ b/lib/sensu/api/http_handler.rb
@@ -1,4 +1,5 @@
 require "sensu/api/routes"
+require "sensu/api/utilities/filter_response_content"
 
 gem "em-http-server", "0.1.8"
 
@@ -9,6 +10,7 @@ module Sensu
   module API
     class HTTPHandler < EM::HttpServer::Server
       include Routes
+      include Utilities::FilterResponseContent
 
       attr_accessor :logger, :settings, :redis, :transport
 
@@ -61,13 +63,20 @@ module Sensu
 
       # Parse the HTTP request query string for parameters. This
       # method creates `@params`, a hash of parsed query parameters,
-      # used by the API routes.
+      # used by the API routes. This method also creates
+      # `@filter_params`, a hash of parsed response content filter
+      # parameters.
       def parse_parameters
         @params = {}
         if @http_query_string
           @http_query_string.split("&").each do |pair|
             key, value = pair.split("=")
             @params[key.to_sym] = value
+            if key.start_with?("filter.")
+              filter_param = key.sub(/^filter\./, "")
+              @filter_params ||= {}
+              @filter_params[filter_param] = value
+            end
           end
         end
       end
@@ -173,6 +182,9 @@ module Sensu
         @response.status = @response_status || 200
         @response.status_string = @response_status_string || "OK"
         if @response_content && @http_request_method != HEAD_METHOD
+          if @http_request_method == GET_METHOD && @filter_params
+            filter_response_content!
+          end
           @response.content_type "application/json"
           @response.content = Sensu::JSON.dump(@response_content)
         end

--- a/lib/sensu/api/utilities/filter_response_content.rb
+++ b/lib/sensu/api/utilities/filter_response_content.rb
@@ -67,7 +67,9 @@ module Sensu
         end
 
         # Filter the response content if filter parameters have been
-        # provided. This method mutates `@response_content`.
+        # provided. This method mutates `@response_content`, only
+        # retaining array items that match the attributes provided via
+        # filter parameters.
         def filter_response_content!
           if @response_content.is_a?(Array) && !@filter_params.empty?
             attributes = {}

--- a/lib/sensu/api/utilities/filter_response_content.rb
+++ b/lib/sensu/api/utilities/filter_response_content.rb
@@ -1,0 +1,85 @@
+module Sensu
+  module API
+    module Utilities
+      module FilterResponseContent
+        # Create a nested hash from a dot notation key and value.
+        #
+        # @param dot_notation [String]
+        # @param value [Object]
+        # @return [Hash]
+        def dot_notation_to_hash(dot_notation, value)
+          hash = {}
+          dot_notation.split(".").reverse.each do |key|
+            if hash.empty?
+              hash = {key.to_sym => value}
+            else
+              hash = {key.to_sym => hash}
+            end
+          end
+          hash
+        end
+
+        # Deep merge two hashes. Nested hashes are deep merged, arrays
+        # are concatenated and duplicate array items are removed.
+        #
+        # @param hash_one [Hash]
+        # @param hash_two [Hash]
+        # @return [Hash] deep merged hash.
+        def deep_merge(hash_one, hash_two)
+          merged = hash_one.dup
+          hash_two.each do |key, value|
+            merged[key] = case
+            when hash_one[key].is_a?(Hash) && value.is_a?(Hash)
+              deep_merge(hash_one[key], value)
+            when hash_one[key].is_a?(Array) && value.is_a?(Array)
+              (hash_one[key] + value).uniq
+            else
+              value
+            end
+          end
+          merged
+        end
+
+        # Determine if all attribute values match those of the
+        # corresponding object attributes. Attributes match if the
+        # value objects are equivalent, are both hashes with matching
+        # key/value pairs (recursive), or have equal string values.
+        #
+        # @param object [Hash]
+        # @param match_attributes [Object]
+        # @param object_attributes [Object]
+        # @return [TrueClass, FalseClass]
+        def attributes_match?(object, match_attributes, object_attributes=nil)
+          object_attributes ||= object
+          match_attributes.all? do |key, value_one|
+            value_two = object_attributes[key]
+            case
+            when value_one == value_two
+              true
+            when value_one.is_a?(Hash) && value_two.is_a?(Hash)
+              attributes_match?(object, value_one, value_two)
+            when value_one.to_s == value_two.to_s
+              true
+            else
+              false
+            end
+          end
+        end
+
+        # Filter the response content if filter parameters have been
+        # provided. This method mutates `@response_content`.
+        def filter_response_content!
+          if @response_content.is_a?(Array) && !@filter_params.empty?
+            attributes = {}
+            @filter_params.each do |key, value|
+              attributes = deep_merge(attributes, dot_notation_to_hash(key, value))
+            end
+            @response_content.select! do |object|
+              attributes_match?(object, attributes)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -259,9 +259,10 @@ module Sensu
     #
     # @param object [Hash]
     # @param match_attributes [Object]
+    # @param support_eval [TrueClass, FalseClass]
     # @param object_attributes [Object]
     # @return [TrueClass, FalseClass]
-    def attributes_match?(object, match_attributes, object_attributes=nil)
+    def attributes_match?(object, match_attributes, support_eval=true, object_attributes=nil)
       object_attributes ||= object
       match_attributes.all? do |key, value_one|
         value_two = object_attributes[key]
@@ -269,10 +270,10 @@ module Sensu
         when value_one == value_two
           true
         when value_one.is_a?(Hash) && value_two.is_a?(Hash)
-          attributes_match?(object, value_one, value_two)
+          attributes_match?(object, value_one, support_eval, value_two)
         when value_one.to_s == value_two.to_s
           true
-        when value_one.is_a?(String) && value_one.start_with?(EVAL_PREFIX)
+        when value_one.is_a?(String) && value_one.start_with?(EVAL_PREFIX) && support_eval
           eval_attribute_value(object, value_one, value_two)
         else
           false

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -239,6 +239,18 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can provide defined checks that match filter parameters" do
+    api_test do
+      http_request(4567, "/checks?filter.name=tokens&filter.interval=1") do |http, body|
+        expect(http.response_header.status).to eq(200)
+        expect(body).to be_kind_of(Array)
+        expect(body.size).to eq(1)
+        expect(body.first[:name]).to eq("tokens")
+        async_done
+      end
+    end
+  end
+
   it "can provide a specific check" do
     api_test do
       http_request(4567, "/checks/merger") do |http, body|

--- a/spec/api/utilities/filter_response_content_spec.rb
+++ b/spec/api/utilities/filter_response_content_spec.rb
@@ -1,0 +1,64 @@
+require "sensu/api/utilities/filter_response_content"
+
+describe "Sensu::API::Utilities::FilterResponseContent" do
+  include Sensu::API::Utilities::FilterResponseContent
+
+  it "can create a nested hash from a dot notation key and value" do
+    hash = dot_notation_to_hash("rspec.foo.bar", 42)
+    expect(hash).to eq({:rspec => {:foo => {:bar => 42}}})
+  end
+
+  it "can deep merge two hashes" do
+    hash_one = {
+      :foo => "foo",
+      :bar => 1,
+      :baz => {
+        :foo => ["foo", "bar"],
+        :bar => {
+          :baz => "baz"
+        }
+      }
+    }
+    hash_two = {
+      :foo => "foo",
+      :bar => 2,
+      :baz => {
+        :foo => ["foo", "baz"],
+        :bar => {
+          :baz => "bar"
+        }
+      }
+    }
+    merged_hash = deep_merge(hash_one, hash_two)
+    expected = {
+      :foo => "foo",
+      :bar => 2,
+      :baz => {
+        :foo => ["foo", "bar", "baz"],
+        :bar => {
+          :baz => "bar"
+        }
+      }
+    }
+    expect(merged_hash).to eq(expected)
+  end
+
+  it "can determine if attributes match an object" do
+    object = {
+      :foo => "foo",
+      :bar => {
+        :baz => "baz"
+      },
+      :qux => 1
+    }
+    attributes = {
+      :foo => "foo",
+      :bar => {
+        :baz => "bar"
+      }
+    }
+    expect(attributes_match?(object, attributes)).to be(false)
+    attributes[:bar][:baz] = "baz"
+    expect(attributes_match?(object, attributes)).to be(true)
+  end
+end

--- a/spec/api/utilities/filter_response_content_spec.rb
+++ b/spec/api/utilities/filter_response_content_spec.rb
@@ -29,7 +29,6 @@ describe "Sensu::API::Utilities::FilterResponseContent" do
         }
       }
     }
-    merged_hash = deep_merge(hash_one, hash_two)
     expected = {
       :foo => "foo",
       :bar => 2,
@@ -40,6 +39,7 @@ describe "Sensu::API::Utilities::FilterResponseContent" do
         }
       }
     }
+    merged_hash = deep_merge(hash_one, hash_two)
     expect(merged_hash).to eq(expected)
   end
 

--- a/spec/api/utilities/filter_response_content_spec.rb
+++ b/spec/api/utilities/filter_response_content_spec.rb
@@ -8,57 +8,50 @@ describe "Sensu::API::Utilities::FilterResponseContent" do
     expect(hash).to eq({:rspec => {:foo => {:bar => 42}}})
   end
 
-  it "can deep merge two hashes" do
-    hash_one = {
-      :foo => "foo",
-      :bar => 1,
-      :baz => {
-        :foo => ["foo", "bar"],
-        :bar => {
-          :baz => "baz"
-        }
-      }
+  it "can filter response content" do
+    @filter_params = {
+      "foo.bar.baz" => 42,
+      "qux" => "rspec"
     }
-    hash_two = {
-      :foo => "foo",
-      :bar => 2,
-      :baz => {
-        :foo => ["foo", "baz"],
-        :bar => {
-          :baz => "bar"
-        }
-      }
-    }
-    expected = {
-      :foo => "foo",
-      :bar => 2,
-      :baz => {
-        :foo => ["foo", "bar", "baz"],
-        :bar => {
-          :baz => "bar"
-        }
-      }
-    }
-    merged_hash = deep_merge(hash_one, hash_two)
-    expect(merged_hash).to eq(expected)
-  end
-
-  it "can determine if attributes match an object" do
-    object = {
-      :foo => "foo",
-      :bar => {
-        :baz => "baz"
+    @response_content = [
+      {
+        :foo => {
+          :bar => {
+            :baz => 42
+          }
+        },
+        :qux => "rspec"
       },
-      :qux => 1
-    }
-    attributes = {
-      :foo => "foo",
-      :bar => {
-        :baz => "bar"
+      {
+        :foo => {
+          :bar => {
+            :baz => 42
+          }
+        },
+        :qux => "rspec",
+        :one => 1
+      },
+      {
+        :foo => {
+          :bar => {
+            :baz => 42
+          }
+        }
+      },
+      {
+        :qux => "rspec"
+      },
+      {
+        :foo => {
+          :bar => {
+            :baz => 42
+          }
+        },
+        :qux => "nope"
       }
-    }
-    expect(attributes_match?(object, attributes)).to be(false)
-    attributes[:bar][:baz] = "baz"
-    expect(attributes_match?(object, attributes)).to be(true)
+    ]
+    filter_response_content!
+    expect(@response_content).to be_kind_of(Array)
+    expect(@response_content.size).to eq(2)
   end
 end

--- a/spec/api/validators/client_spec.rb
+++ b/spec/api/validators/client_spec.rb
@@ -1,15 +1,18 @@
 require "sensu/api/validators/client"
 
-describe "Sensu::API::Process" do
+describe "Sensu::API::Validators::Client" do
+  before do
+    @validator = Sensu::API::Validators::Client.new
+  end
+
   it "can validate a client definition" do
     client = {
       :name => "i-424242",
       :address => "127.0.0.1",
       :subscriptions => ["test"]
     }
-    validator = Sensu::API::Validators::Client.new
-    expect(validator.valid?(client)).to be(true)
+    expect(@validator.valid?(client)).to be(true)
     client[:name] = 42
-    expect(validator.valid?(client)).to be(false)
+    expect(@validator.valid?(client)).to be(false)
   end
 end


### PR DESCRIPTION
## Description
This pull request adds API response content filtering for GET requests. Filter parameters use dot notation attribute keys in order to support nested attributes/values. Filter parameters must begin with `filter.`.

Some example API queries that this pull request enables:

`/events?filter.check.name=check_http`

`/events?filter.client.name=i-424242&filter.check.name=check_haproxy`

`/clients?filter.client.environment=production`

## Related Issue
https://github.com/sensu/sensu/issues/1220
https://github.com/sensu/sensu/issues/1253
https://github.com/sensu/sensu/issues/838
https://github.com/sensu/sensu/issues/550

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
