### PR TITLE
[api/clients] add per-client subscripton automatically on create

### DIFF
--- a/lib/sensu/api/routes/clients.rb
+++ b/lib/sensu/api/routes/clients.rb
@@ -19,6 +19,7 @@ module Sensu
             client[:timestamp] = Time.now.to_i
             validator = Validators::Client.new
             if validator.valid?(client)
+              client[:subscriptions] = (client[:subscriptions] + ["client:#{client[:name]}"]).uniq
               @redis.set("client:#{client[:name]}", Sensu::JSON.dump(client)) do
                 @redis.sadd("clients", client[:name]) do
                   @response_content = {:name => client[:name]}

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -476,7 +476,8 @@ describe "Sensu::API::Process" do
           expect(body).to be_kind_of(Hash)
           expect(body[:name]).to eq("i-888888")
           expect(body[:address]).to eq("8.8.8.8")
-          expect(body[:subscriptions]).to eq(["test"])
+          expect(body[:subscriptions]).to include("client:i-888888")
+          expect(body[:subscriptions]).to include("test")
           expect(body[:keepalives]).to be(false)
           expect(body[:timestamp]).to be_within(10).of(epoch)
           async_done


### PR DESCRIPTION
## Description

This change ensures that per-client subscriptions are added to each client created via the `/clients` API endpoint.

## Related Issue

Relates to #1596 

## Motivation and Context

Clients created by posting to `/clients` API endpoint are not getting per-client subscriptions added automatically, which makes it impossible to silence them individually. Silencing is expected to work for both real and proxy clients.

## How Has This Been Tested?

Extended unit test to ensure client subscription is added automatically.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
