### PR TITLE
Log API response time

### DIFF
--- a/lib/sensu/api/http_handler.rb
+++ b/lib/sensu/api/http_handler.rb
@@ -21,6 +21,7 @@ module Sensu
       # @result [Hash]
       def request_details
         return @request_details if @request_details
+        @request_start_time = Time.now.to_f
         _, remote_address = Socket.unpack_sockaddr_in(get_peername)
         @request_details = {
           :remote_address => remote_address,
@@ -42,12 +43,14 @@ module Sensu
         @logger.debug("api request", request_details)
       end
 
-      # Log the HTTP response.
+      # Log the HTTP response. This method calculates the
+      # request/response time.
       def log_response
         @logger.info("api response", {
           :request => request_details,
           :status => @response.status,
-          :content_length => @response.content.to_s.bytesize
+          :content_length => @response.content.to_s.bytesize,
+          :time => (Time.now.to_f - @request_start_time).round(3)
         })
       end
 


### PR DESCRIPTION
Log Sensu API response times, for example:

```
{"timestamp":"2017-03-08T10:44:44.319572-0800","level":"info","message":"api response","request":{"remote_address":"127.0.0.1","user_agent":"curl/7.35.0","method":"GET","uri":"/info","query_string":null,"body":""},"status":200,"content_length":200,"time":0.002}
```

Closes https://github.com/sensu/sensu/issues/1061