### PR TITLE
Sensu server tasks instead of a single leader

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -1096,7 +1096,7 @@ module Sensu
       #
       # @return [Integer]
       def create_lock_timestamp
-        (Time.now.to_f * 1000).to_i
+        (Time.now.to_f * 10000000).to_i
       end
 
       # Create/return the unique Sensu server ID for the current
@@ -1154,7 +1154,7 @@ module Sensu
       # Relinquish all Sensu server tasks, if any.
       def relinquish_tasks
         unless @tasks.empty?
-          @tasks.each do |task|
+          @tasks.dup.each do |task|
             relinquish_task(task)
           end
         else
@@ -1224,7 +1224,7 @@ module Sensu
           else
             @redis.get("lock:task:#{task}") do |current_lock_timestamp|
               new_lock_timestamp = create_lock_timestamp
-              if new_lock_timestamp - current_lock_timestamp.to_i >= 30000
+              if new_lock_timestamp - current_lock_timestamp.to_i >= 300000000
                 @redis.getset("lock:task:#{task}", new_lock_timestamp) do |previous_lock_timestamp|
                   if previous_lock_timestamp == current_lock_timestamp
                     setup_task(task, &callback)

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -699,7 +699,7 @@ describe "Sensu::Server::Process" do
       check = check_template
       check[:cron] = "* * * * *"
       @server.schedule_checks([check])
-      expect(@server.instance_variable_get(:@timers)[:leader].size).to eq(1)
+      expect(@server.instance_variable_get(:@timers)[:tasks][:check_request_publisher].size).to eq(1)
       async_done
     end
   end
@@ -857,43 +857,43 @@ describe "Sensu::Server::Process" do
     end
   end
 
-  it "can be the leader and resign" do
-    async_wrapper do
-      @server.setup_connections do
-        redis.flushdb do
-          @server.request_leader_election
-          timer(1) do
-            expect(@server.is_leader).to be(true)
-            @server.resign_as_leader
-            expect(@server.is_leader).to be(false)
-            async_done
-          end
-        end
-      end
-    end
-  end
-
-  it "can be the only leader" do
-    async_wrapper do
-      server1 = @server.clone
-      server2 = @server.clone
-      server1.setup_connections do
-        server2.setup_connections do
-          redis.flushdb do
-            lock_timestamp = (Time.now.to_f * 1000).to_i - 60000
-            redis.set("lock:leader", lock_timestamp) do
-              server1.setup_leader_monitor
-              server2.setup_leader_monitor
-              timer(3) do
-                expect([server1.is_leader, server2.is_leader].uniq.size).to eq(2)
-                async_done
-              end
-            end
-          end
-        end
-      end
-    end
-  end
+#  it "can be the leader and resign" do
+#    async_wrapper do
+#      @server.setup_connections do
+#        redis.flushdb do
+#          @server.request_leader_election
+#          timer(1) do
+#            expect(@server.is_leader).to be(true)
+#            @server.resign_as_leader
+#            expect(@server.is_leader).to be(false)
+#            async_done
+#          end
+#        end
+#      end
+#    end
+#  end
+#
+#  it "can be the only leader" do
+#    async_wrapper do
+#      server1 = @server.clone
+#      server2 = @server.clone
+#      server1.setup_connections do
+#        server2.setup_connections do
+#          redis.flushdb do
+#            lock_timestamp = (Time.now.to_f * 1000).to_i - 60000
+#            redis.set("lock:leader", lock_timestamp) do
+#              server1.setup_leader_monitor
+#              server2.setup_leader_monitor
+#              timer(3) do
+#                expect([server1.is_leader, server2.is_leader].uniq.size).to eq(2)
+#                async_done
+#              end
+#            end
+#          end
+#        end
+#      end
+#    end
+#  end
 
   it "can update the server registry" do
     async_wrapper do
@@ -907,6 +907,7 @@ describe "Sensu::Server::Process" do
                 server = Sensu::JSON.load(server_json)
                 expect(server[:id]).to eq(@server.server_id)
                 expect(server[:timestamp]).to be_within(5).of(Time.now.to_i)
+                expect(server[:tasks]).to be_kind_of(Array)
                 async_done
               end
             end


### PR DESCRIPTION
## Description

Split up Sensu server leader responsibilities into Sensu server tasks, allowing them to be distributed amongst the available Sensu servers.

The Sensu server task list is sorted by priority, tasks which should have server elections first in order to run sooner than later: `["check_request_publisher", "client_monitor", "check_result_monitor"]`.

As Sensu servers are elected for a task, they increase their election delay for further task elections, giving the other servers a better chance of being elected for a better distribution.

## Related Issue

Closes https://github.com/sensu/sensu/issues/1537

## Motivation and Context

More Sensu server utilization/load distribution.

## How Has This Been Tested?

RSpec and manual testing, including several failover scenarios.

## Screenshots:

API `/info` on my laptop, running two instances of Sensu server:

![screenshot - 17-03-18 - 04 14 44 pm](https://cloud.githubusercontent.com/assets/149630/24076750/0ccbbfdc-0bf6-11e7-98ab-fdd046abc0a7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.