### PR TITLE
Added API GET /settings with redaction

### DIFF
--- a/lib/sensu/api/routes.rb
+++ b/lib/sensu/api/routes.rb
@@ -1,3 +1,4 @@
+require "sensu/api/routes/settings"
 require "sensu/api/routes/info"
 require "sensu/api/routes/health"
 require "sensu/api/routes/clients"
@@ -13,6 +14,7 @@ require "sensu/api/routes/silenced"
 module Sensu
   module API
     module Routes
+      include Settings
       include Info
       include Health
       include Clients
@@ -32,6 +34,7 @@ module Sensu
       OPTIONS_METHOD = "OPTIONS".freeze
 
       GET_ROUTES = [
+        [SETTINGS_URI, :get_settings],
         [INFO_URI, :get_info],
         [HEALTH_URI, :get_health],
         [CLIENTS_URI, :get_clients],

--- a/lib/sensu/api/routes/settings.rb
+++ b/lib/sensu/api/routes/settings.rb
@@ -1,0 +1,23 @@
+require "sensu/utilities"
+
+module Sensu
+  module API
+    module Routes
+      module Settings
+        include Utilities
+
+        SETTINGS_URI = /^\/settings$/
+
+        # GET /settings
+        def get_settings
+          if @params[:redacted] == "false"
+            @response_content = @settings.to_hash
+          else
+            @response_content = redact_sensitive(@settings.to_hash)
+          end
+          respond
+        end
+      end
+    end
+  end
+end

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -44,6 +44,20 @@ describe "Sensu::API::Process" do
     expect(handler.integer_parameter("42\nabc")).to eq(nil)
   end
 
+  it "can provide the running configuration settings with redaction" do
+    api_test do
+      http_request(4567, "/settings") do |http, body|
+        expect(http.response_header.status).to eq(200)
+        expect(body[:client][:name]).to eq("i-424242")
+        expect(body[:client][:service][:password]).to eq("REDACTED")
+        http_request(4567, "/settings?redacted=false") do |http, body|
+          expect(body[:client][:service][:password]).to eq("secret")
+          async_done
+        end
+      end
+    end
+  end
+
   it "can provide basic version and health information" do
     api_test do
       http_request(4567, "/info") do |http, body|


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the API GET `/settings` endpoint, which provides the running configuration settings, with sensitive values redacted by default. The `?redacted=false` query parameter can be used to disable redaction.

## Related Issue

https://github.com/sensu/sensu/issues/1503

## Motivation and Context

Provide the functionality of CLI `--print_config` and the Sensu client HTTP socket GET `/settings` via the Sensu API.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
