### PR TITLE
Use sensu-settings 10 & utilize settings hexdigest

### DIFF
--- a/lib/sensu/api/routes/info.rb
+++ b/lib/sensu/api/routes/info.rb
@@ -16,7 +16,10 @@ module Sensu
             servers_info do |servers|
               @response_content = {
                 :sensu => {
-                  :version => VERSION
+                  :version => VERSION,
+                  :settings => {
+                    :hexdigest => @settings.hexdigest
+                  }
                 },
                 :transport => transport,
                 :redis => {

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.2"
 
 gem "sensu-json", "2.1.0"
 gem "sensu-logger", "1.2.1"
-gem "sensu-settings", "9.9.0"
+gem "sensu-settings", "10.0.0"
 gem "sensu-extension", "1.5.1"
 gem "sensu-extensions", "1.7.1"
 gem "sensu-transport", "7.0.2"
@@ -142,6 +142,7 @@ module Sensu
         @logger.fatal("SENSU NOT RUNNING!")
         exit 2
       end
+      @settings.set_env!
     end
 
     # Load Sensu extensions and log any notices. Set the logger and

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -1288,6 +1288,12 @@ module Sensu
                 :system => cpu_system
               }
             },
+            :sensu => {
+              :version => VERSION,
+              :settings => {
+                :hexdigest => @settings.hexdigest
+              }
+            },
             :timestamp => Time.now.to_i
           }
           @redis.sadd("servers", server_id)

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.2"
   s.add_dependency "sensu-json", "2.1.0"
   s.add_dependency "sensu-logger", "1.2.1"
-  s.add_dependency "sensu-settings", "9.9.0"
+  s.add_dependency "sensu-settings", "10.0.0"
   s.add_dependency "sensu-extension", "1.5.1"
   s.add_dependency "sensu-extensions", "1.7.1"
   s.add_dependency "sensu-transport", "7.0.2"

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -63,6 +63,7 @@ describe "Sensu::API::Process" do
       http_request(4567, "/info") do |http, body|
         expect(http.response_header.status).to eq(200)
         expect(body[:sensu][:version]).to eq(Sensu::VERSION)
+        expect(body[:sensu][:settings][:hexdigest]).to be_kind_of(String)
         expect(body[:redis][:connected]).to be(true)
         expect(body[:transport][:name]).to eq("rabbitmq")
         expect(body[:transport][:connected]).to be(true)

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -908,8 +908,10 @@ describe "Sensu::Server::Process" do
                 expect(server_json).to be_kind_of(String)
                 server = Sensu::JSON.load(server_json)
                 expect(server[:id]).to eq(@server.server_id)
-                expect(server[:timestamp]).to be_within(5).of(Time.now.to_i)
                 expect(server[:tasks]).to be_kind_of(Array)
+                expect(server[:sensu][:version]).to eq(Sensu::VERSION)
+                expect(server[:sensu][:settings][:hexdigest]).to be_kind_of(String)
+                expect(server[:timestamp]).to be_within(5).of(Time.now.to_i)
                 async_done
               end
             end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use sensu-settings 10.0.0, which decoupled state management from loading, and added settings hexdigest. This pull-request utilizes the settings hexdigest in the Sensu server registry and Sensu API `/info` endpoint, to help users determine if a Sensu server's configuration differs from the rest.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Decoupling state management from loading enables some Sensu Enterprise improvements.

Exposing Sensu server settings hexdigests via the API allows users to determine if a Sensu server's configuration differs from the rest (snowflake).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots

![screenshot - 17-03-19 - 05 36 21 pm](https://cloud.githubusercontent.com/assets/149630/24086382/c9f3458c-0ccb-11e7-8cdf-2cdc845043d9.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
