### PR TITLE
Add Rubocop for static code analysis 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,38 @@
+AllCops:
+  Exclude:
+    - 'spec/extensions/mutators/syntax.rb'
+Metrics/AbcSize:
+  Max: 30
+Metrics/BlockLength:
+  Max: 55
+Metrics/ClassLength:
+  Max: 300
+Metrics/LineLength:
+  Max: 120
+Metrics/MethodLength:
+  Max: 55
+Metrics/ModuleLength:
+  Max: 300
+Metrics/CyclomaticComplexity:
+  Max: 12
+Style/StringLiterals:
+  Enabled: false
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+Style/RegexpLiteral:
+  EnforcedStyle: slashes
+  AllowInnerSlashes: true
+Style/Proc:
+  Enabled: false
+Style/BracesAroundHashParameters:
+  Enabled: false
+Style/SpaceInsideHashLiteralBraces:
+  Enabled: false
+Style/SpaceAroundEqualsInParameterDefault:
+  Enabled: false
+Style/IndentHash:
+  Enabled: false
+Style/AccessorMethodName:
+  Enabled: false
+Style/UnlessElse:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gemspec
+gem 'rubocop', '~> 0.47.1', :require => false

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new
 
 task :default => :spec


### PR DESCRIPTION
## Description

Add rubocop, a Ruby static code analyzer.

## Related Issue

Closes #1538

## Motivation and Context

I believe that introducing a static code analyzer into our workflow will increase uniformity and readability in the code base.

## How Has This Been Tested?

See https://gist.github.com/cwjohnston/5c0396d66f9fa4810d49f900bdd591af for a summary and full output of this rubocop configuration as run against `release/0.29` branch

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
