### PR TITLE
Support client invalidation on deletion

### DIFF
--- a/lib/sensu/api/routes/clients.rb
+++ b/lib/sensu/api/routes/clients.rb
@@ -117,9 +117,7 @@ module Sensu
           signature_key = "#{client_key}:signature"
           @redis.get(client_key) do |client_json|
             unless client_json.nil?
-              if @params[:invalidate]
-                @redis.set(signature_key, "invalidated")
-              end
+              @redis.set(signature_key, "invalidated") if @params[:invalidate]
               @redis.hgetall("events:#{client_name}") do |events|
                 events.each do |check_name, event_json|
                   resolve_event(event_json)

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -155,7 +155,7 @@ module Sensu
             if (signature.nil? || signature.empty?) && client[:signature]
               @redis.set(signature_key, client[:signature])
             end
-            if signature.nil? || signature.empty? || (client[:signature] == signature)
+            if signature.nil? || signature.empty? || client[:signature] == signature
               @redis.multi
               @redis.set(client_key, Sensu::JSON.dump(client))
               @redis.sadd("clients", client[:name])
@@ -635,7 +635,7 @@ module Sensu
             end
           else
             @redis.get("client:#{client_key}:signature") do |signature|
-              if (signature.nil? || signature.empty?) || (result[:signature] == signature)
+              if signature.nil? || signature.empty? || result[:signature] == signature
                 client = create_client(client_key)
                 client[:type] = "proxy" if result[:check][:source]
                 update_client_registry(client) do

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -635,7 +635,7 @@ module Sensu
             end
           else
             @redis.get("client:#{client_key}:signature") do |signature|
-              if (signature.nil? || signature.empty?) || (signature == result[:signature])
+              if (signature.nil? || signature.empty?) || (result[:signature] == signature)
                 client = create_client(client_key)
                 client[:type] = "proxy" if result[:check][:source]
                 update_client_registry(client) do

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -573,6 +573,26 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can delete a client and invalidate keepalives and check results until deleted" do
+    api_test do
+      http_request(4567, "/clients/i-424242?invalidate=true", :delete) do |http, body|
+        expect(http.response_header.status).to eq(202)
+        expect(body).to include(:issued)
+        async_done
+      end
+    end
+  end
+
+  it "can delete a client and invalidate keepalives and check results for an hour after deletion" do
+    api_test do
+      http_request(4567, "/clients/i-424242?invalidate=true&invalidate_expire=3600", :delete) do |http, body|
+        expect(http.response_header.status).to eq(202)
+        expect(body).to include(:issued)
+        async_done
+      end
+    end
+  end
+
   it "can provide a specific defined check" do
     api_test do
       http_request(4567, "/checks/tokens") do |http, body|


### PR DESCRIPTION
## Description
Support invalidating a client when deleting it via the API, disallowing further client keepalives and check results until the client is either successfully removed from the client registry or for a specified duration of time.

Examples:

Invalidate a client until it is removed from the registry:

API DELETE `/clients/:name?invalidate=true`

Invalidate a client for an hour:

API DELETE `/clients/:name?invalidate=true&invalidate_expire=3600`

## Related Issue
https://github.com/sensu/sensu/issues/1541

## Motivation and Context
Some infrastructure system/vm/container life cycle workflows do not allow for Sensu client decommissioning or users do not care for the keepalive event handler method of client registry cleanup.

## How Has This Been Tested?
Added RSpec API tests.

Manual testing with running services:

```
{"timestamp":"2017-03-22T11:33:11.219089-0700","level":"debug","message":"updating client registry","client":{"name":"i-424242","address":"127.0.0.1","signature":"foobar","subscriptions":["test","roundrobin:test","all","client:i-424242"],"keepalive":{"th
resholds":{"warning":10}},"deregister":true,"deregistration":{"handler":"DEREGISTER_HANDLER"},"version":"0.28.4","nested":{"attribute":true},"service":{"password":"REDACTED"},"empty":{},"localhost":"fail","http_socket":{"user":"foo","password":"REDACTED"
,"bind":"127.0.0.1","port":3031},"timestamp":1490207591}}
{"timestamp":"2017-03-22T11:33:11.219551-0700","level":"warn","message":"invalid client signature","client":{"name":"i-424242","address":"127.0.0.1","signature":"foobar","subscriptions":["test","roundrobin:test","all","client:i-424242"],"keepalive":{"thr
esholds":{"warning":10}},"deregister":true,"deregistration":{"handler":"DEREGISTER_HANDLER"},"version":"0.28.4","nested":{"attribute":true},"service":{"password":"REDACTED"},"empty":{},"localhost":"fail","http_socket":{"user":"foo","password":"REDACTED",
"bind":"127.0.0.1","port":3031},"timestamp":1490207591},"signature":"invalidated"}
{"timestamp":"2017-03-22T11:33:11.219614-0700","level":"warn","message":"not updating client in the registry","client":{"name":"i-424242","address":"127.0.0.1","signature":"foobar","subscriptions":["test","roundrobin:test","all","client:i-424242"],"keepa
live":{"thresholds":{"warning":10}},"deregister":true,"deregistration":{"handler":"DEREGISTER_HANDLER"},"version":"0.28.4","nested":{"attribute":true},"service":{"password":"REDACTED"},"empty":{},"localhost":"fail","http_socket":{"user":"foo","password":
"REDACTED","bind":"127.0.0.1","port":3031},"timestamp":1490207591}}
```

```
{"timestamp":"2017-03-22T11:34:01.297743-0700","level":"warn","message":"invalid check result signature","result":{"client":"i-424242","check":{"source":"switch-y","command":"/bin/true","name":"source","issued":1490207641,"subscribers":["test"],"interval
":1,"executed":1490207641,"duration":0.006,"output":"","status":0},"signature":"foobar"},"signature":"invalidated"}
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
