### PR TITLE
Sensu API return a 405 when an HTTP method is not allowed for a route

### DIFF
--- a/lib/sensu/api/http_handler.rb
+++ b/lib/sensu/api/http_handler.rb
@@ -357,10 +357,12 @@ module Sensu
       end
 
       # Route the HTTP request. OPTIONS HTTP requests will always
-      # return a `200` with no response content. The route regular
-      # expressions and associated route method calls are provided by
-      # `ROUTES`. If a route match is not found, this method responds
-      # with a `404` (Not Found) HTTP response.
+      # return a `200` with no response content. This method uses
+      # `determine_route_method()` to determine the symbolized route
+      # method to send/call. If a route method does not exist for the
+      # HTTP request method and URI, this method uses
+      # `allowed_http_methods?()` to determine if a 404 (Not Found) or
+      # 405 (Method Not Allowed) HTTP response should be used.
       def route_request
         if @http_request_method == OPTIONS_METHOD
           respond

--- a/lib/sensu/api/http_handler.rb
+++ b/lib/sensu/api/http_handler.rb
@@ -297,6 +297,14 @@ module Sensu
         respond
       end
 
+      # Respond to the HTTP request with a `405` (Method Not Allowed) response.
+      def method_not_allowed!(allowed_http_methods=[])
+        @response.headers["Allow"] = allowed_http_methods.join(", ")
+        @response_status = 405
+        @response_status_string = "Method Not Allowed"
+        respond
+      end
+
       # Respond to the HTTP request with a `412` (Precondition Failed)
       # response.
       def precondition_failed!
@@ -313,6 +321,41 @@ module Sensu
         respond
       end
 
+      # Determine the allowed HTTP methods for a route. The route
+      # regular expressions and associated route method calls are
+      # provided by `ROUTES`. This method returns an array of HTTP
+      # methods that have a route that matches the HTTP request URI.
+      #
+      # @return [Array]
+      def allowed_http_methods?
+        ROUTES.map { |http_method, routes|
+          match = routes.detect do |route|
+            @http_request_uri =~ route[0]
+          end
+          match ? http_method : nil
+        }.flatten.compact
+      end
+
+      # Determine the route method for the HTTP request method and
+      # URI. The route regular expressions and associated route method
+      # calls are provided by `ROUTES`. This method will return the
+      # first route method name (Ruby symbol) that has matching URI
+      # regular expression. If an HTTP method is not supported, or
+      # there is not a matching regular expression, `nil` will be
+      # returned.
+      #
+      # @return [Symbol]
+      def determine_route_method
+        if ROUTES.has_key?(@http_request_method)
+          route = ROUTES[@http_request_method].detect do |route|
+            @http_request_uri =~ route[0]
+          end
+          route ? route[1] : nil
+        else
+          nil
+        end
+      end
+
       # Route the HTTP request. OPTIONS HTTP requests will always
       # return a `200` with no response content. The route regular
       # expressions and associated route method calls are provided by
@@ -321,17 +364,18 @@ module Sensu
       def route_request
         if @http_request_method == OPTIONS_METHOD
           respond
-        elsif ROUTES.has_key?(@http_request_method)
-          route = ROUTES[@http_request_method].detect do |route|
-            @http_request_uri =~ route[0]
-          end
-          unless route.nil?
-            send(route[1])
-          else
-            not_found!
-          end
         else
-          not_found!
+          route_method = determine_route_method
+          if route_method
+            send(route_method)
+          else
+            allowed_http_methods = allowed_http_methods?
+            if allowed_http_methods.empty?
+              not_found!
+            else
+              method_not_allowed!(allowed_http_methods)
+            end
+          end
         end
       end
 

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -58,6 +58,25 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can respond with a 404 when a route could not be found" do
+    api_test do
+      http_request(4567, "/missing") do |http, body|
+        expect(http.response_header.status).to eq(404)
+        async_done
+      end
+    end
+  end
+
+  it "can respond with a 405 when a http method is not supported by a route" do
+    api_test do
+      http_request(4567, "/info", :put) do |http, body|
+        expect(http.response_header.status).to eq(405)
+        expect(http.response_header["Allow"]).to eq("GET, HEAD")
+        async_done
+      end
+    end
+  end
+
   it "can provide basic version and health information" do
     api_test do
       http_request(4567, "/info") do |http, body|


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Return an HTTP 405 response when a route exists but does not support a HTTP method, i.e. PUTS.

## Related Issue
Closes https://github.com/sensu/sensu/issues/1641

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
