### PR TITLE
Sensu CLI defaults for config file & directory

### DIFF
--- a/lib/sensu/cli.rb
+++ b/lib/sensu/cli.rb
@@ -11,6 +11,12 @@ module Sensu
     # @return [Hash] options
     def self.read(arguments=ARGV)
       options = {}
+      if File.exist?("/etc/sensu/config.json")
+        options[:config_file] = "/etc/sensu/config.json"
+      end
+      if Dir.exist?("/etc/sensu/conf.d")
+        options[:config_dirs] = "/etc/sensu/conf.d"
+      end
       optparse = OptionParser.new do |opts|
         opts.on("-h", "--help", "Display this message") do
           puts opts
@@ -20,10 +26,10 @@ module Sensu
           puts VERSION
           exit
         end
-        opts.on("-c", "--config FILE", "Sensu JSON config FILE") do |file|
+        opts.on("-c", "--config FILE", "Sensu JSON config FILE. Default: /etc/sensu/config.json (if exists)") do |file|
           options[:config_file] = file
         end
-        opts.on("-d", "--config_dir DIR[,DIR]", "DIR or comma-delimited DIR list for Sensu JSON config files") do |dir|
+        opts.on("-d", "--config_dir DIR[,DIR]", "DIR or comma-delimited DIR list for Sensu JSON config files. Default: /etc/sensu/conf.d (if exists)") do |dir|
           options[:config_dirs] = dir.split(",")
         end
         opts.on("--validate_config", "Validate the compiled configuration and exit") do

--- a/lib/sensu/cli.rb
+++ b/lib/sensu/cli.rb
@@ -15,7 +15,7 @@ module Sensu
         options[:config_file] = "/etc/sensu/config.json"
       end
       if Dir.exist?("/etc/sensu/conf.d")
-        options[:config_dirs] = "/etc/sensu/conf.d"
+        options[:config_dirs] = ["/etc/sensu/conf.d"]
       end
       optparse = OptionParser.new do |opts|
         opts.on("-h", "--help", "Display this message") do

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -6,15 +6,18 @@ describe "Sensu::CLI" do
   include Helpers
 
   it "can provide default configuration options" do
+    expect(File).to receive(:exist?) do |value|
+      true
+    end
+    expect(Dir).to receive(:exist?) do |value|
+      true
+    end
     options = Sensu::CLI.read
-    if File.exist?("/etc/sensu/config.json")
-      expect(options[:config_file]).to eq("/etc/sensu/config.json")
-    end
-    if Dir.exists?("/etc/sensu/conf.d")
-      expect(options[:config_dirs]).to eq("/etc/sensu/conf.d")
-    end
-    other_options = options.reject { |key, value| [:config_file, :config_dirs].include?(key) }
-    expect(other_options).to eq({})
+    expected = {
+      :config_file => "/etc/sensu/config.json",
+      :config_dirs => ["/etc/sensu/conf.d"]
+    }
+    expect(options).to eq(expected)
   end
 
   it "can parse command line arguments" do

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -6,12 +6,8 @@ describe "Sensu::CLI" do
   include Helpers
 
   it "can provide default configuration options" do
-    expect(File).to receive(:exist?) do
-      true
-    end
-    expect(Dir).to receive(:exist?) do
-      true
-    end
+    expect(File).to receive(:exist?) { true }
+    expect(Dir).to receive(:exist?) { true }
     options = Sensu::CLI.read
     expected = {
       :config_file => "/etc/sensu/config.json",

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -6,10 +6,10 @@ describe "Sensu::CLI" do
   include Helpers
 
   it "can provide default configuration options" do
-    expect(File).to receive(:exist?) do |value|
+    expect(File).to receive(:exist?) do
       true
     end
-    expect(Dir).to receive(:exist?) do |value|
+    expect(Dir).to receive(:exist?) do
       true
     end
     options = Sensu::CLI.read

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -5,8 +5,16 @@ require "sensu/cli"
 describe "Sensu::CLI" do
   include Helpers
 
-  it "does not provide default configuration options" do
-    expect(Sensu::CLI.read).to eq(Hash.new)
+  it "can provide default configuration options" do
+    options = Sensu::CLI.read
+    if File.exist?("/etc/sensu/config.json")
+      expect(options[:config_file]).to eq("/etc/sensu/config.json")
+    end
+    if Dir.exists?("/etc/sensu/conf.d")
+      expect(options[:config_dirs]).to eq("/etc/sensu/conf.d")
+    end
+    other_options = options.reject { |key, value| [:config_file, :config_dirs].include?(key) }
+    expect(other_options).to eq({})
   end
 
   it "can parse command line arguments" do
@@ -36,10 +44,7 @@ describe "Sensu::CLI" do
       "-v",
       "-L", "warn"
     ])
-    expected = {
-      :log_level => :warn
-    }
-    expect(options).to eq(expected)
+    expect(options[:log_level]).to eq(:warn)
   end
 
   it "exits when an invalid log level is provided" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull-request introduces CLI option default values for `config_file` and `config_dirs`. The default values, `/etc/sensu/config.json` and `/etc/sensu/conf.d`, are only set if the file/directory resource exists.

These changes will help Sensu users run `--print_config` and `--validate_config` successfully in production, as many users forget to also use the `-c` and `-d` arguments.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
