### PR TITLE
Prevent extension installation when EMBEDDED_RUBY=false

### DIFF
--- a/exe/sensu-install
+++ b/exe/sensu-install
@@ -148,6 +148,11 @@ module Sensu
       end
 
       def install_extensions(extensions, options={})
+        if ENV["EMBEDDED_RUBY"] == "false"
+          log "EMBEDDED_RUBY must be set to true in order to install extensions"
+          log "failed to install extensions: #{extensions}"
+          exit 2
+        end
         log "installing Sensu extensions ..."
         log "provided Sensu extensions: #{extensions}" if options[:verbose]
         extension_gems = extensions.map do |extension|


### PR DESCRIPTION
Fixes #1678.

## Description
Prevents the installation of extensions using the `sensu-install` tool if `EMBEDDED_RUBY=false`.

## Related Issue
#1678 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Set `EMBEDDED_RUBY=false` on my local system & ensured that `sensu-install` exited as expected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
