### PR TITLE
Acknowledge keepalives on next EM tick

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -187,14 +187,14 @@ module Sensu
           @logger.debug("received keepalive", :message => message)
           begin
             client = Sensu::JSON.load(message)
-            update_client_registry(client) do
-              @transport.ack(message_info)
-            end
+            update_client_registry(client)
           rescue Sensu::JSON::ParseError => error
             @logger.error("failed to parse keepalive payload", {
               :message => message,
               :error => error.to_s
             })
+          end
+          EM::next_tick do
             @transport.ack(message_info)
           end
         end

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -411,7 +411,7 @@ describe "Sensu::API::Process" do
                 http_request(4567, "/events/i-424242/signature_test", :delete) do |http, body|
                   expect(http.response_header.status).to eq(202)
                   expect(body).to include(:issued)
-                  timer(2) do
+                  timer(3) do
                     redis.hget("events:i-424242", "signature_test") do |event_json|
                       expect(event_json).to be_nil
                       async_done
@@ -514,7 +514,7 @@ describe "Sensu::API::Process" do
                 http_request(4567, "/incidents/i-424242/signature_test", :delete) do |http, body|
                   expect(http.response_header.status).to eq(202)
                   expect(body).to include(:issued)
-                  timer(2) do
+                  timer(3) do
                     redis.hget("events:i-424242", "signature_test") do |event_json|
                       expect(event_json).to be_nil
                       async_done


### PR DESCRIPTION
We discovered a situation where poor Redis performance can negatively impact keepalive processing, potentially triggering a compounding failure that Sensu is unable to recover from (unless Redis is flushed and its performance improves). Keepalive acknowledgments were nested within several Redis commands/operations, in the event of degrading Redis performance, the keepalive queue would back up, triggering keepalive events that produced additional Redis commands/operations, further taxing Redis, exacerbating the issue. Moving keepalive acknowledgments out of the nested Redis commands/operations to the next tick of the EventMachine reactor removes any guarantee that the keepalive successfully updated the client registry, however, it avoids this failure situation entirely.