### PR TITLE
Bump eventmachine to version 1.2.5

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -1,6 +1,6 @@
 require "rubygems"
 
-gem "eventmachine", "1.2.2"
+gem "eventmachine", "1.2.5"
 
 gem "sensu-json", "2.1.0"
 gem "sensu-logger", "1.2.1"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.has_rdoc    = false
 
-  s.add_dependency "eventmachine", "1.2.2"
+  s.add_dependency "eventmachine", "1.2.5"
   s.add_dependency "sensu-json", "2.1.0"
   s.add_dependency "sensu-logger", "1.2.1"
   s.add_dependency "sensu-settings", "10.3.0"


### PR DESCRIPTION
## Description

Update dependencies to bring in eventmachine 1.2.5

This new version of eventmachine includes fixes for large one-shot timer intervals related to cron scheduling. (https://github.com/eventmachine/eventmachine/pull/784, https://github.com/eventmachine/eventmachine/pull/793)

## Related Issue

Closes #1665 

## Motivation and Context

> If a cron checks next execution is too far away, the resulting value is too large for EM to handle

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
