### PR TITLE
Extend basic auth to info and results endpoints

### DIFF
--- a/lib/sensu/client/http_socket.rb
+++ b/lib/sensu/client/http_socket.rb
@@ -188,7 +188,7 @@ module Sensu
               :http_request_uri => @http_request_uri
             })
             send_response(405, "Method Not Allowed", {
-              :response => "Valid methods for this endpoint: #{reqdef['methods'].keys}"
+              :response => "Valid methods for this endpoint: #{endpoint['methods'].keys}"
             })
           end
         else

--- a/lib/sensu/client/http_socket.rb
+++ b/lib/sensu/client/http_socket.rb
@@ -87,6 +87,14 @@ module Sensu
         false
       end
 
+      def unauthorized_response
+        @logger.warn("http socket refusing to serve unauthorized request")
+        @response.headers["WWW-Authenticate"] = 'Basic realm="Sensu Client Restricted Area"'
+        send_response(401, "Unauthorized", {
+          :response => "You must be authenticated using your http_options user and password settings"
+        })
+      end
+
       def send_response(status, status_string, content)
         @logger.debug("http socket sending response", {
           :status => status,
@@ -100,6 +108,9 @@ module Sensu
       end
 
       def process_request_info
+        if @settings[:client][:http_socket][:protect_all_endpoints]
+          return unauthorized_response unless authorized?
+        end
         transport_info do |info|
           send_response(200, "OK", {
             :sensu => {
@@ -111,6 +122,9 @@ module Sensu
       end
 
       def process_request_results
+        if @settings[:client][:http_socket][:protect_all_endpoints]
+          return unauthorized_response unless authorized?
+        end
         if @http[:content_type] and @http[:content_type] == "application/json" and @http_content
           begin
             check = Sensu::JSON::load(@http_content)
@@ -125,19 +139,12 @@ module Sensu
       end
 
       def process_request_settings
-        if authorized?
-          @logger.info("http socket responding to request for configuration settings")
-          if @http_query_string and @http_query_string.downcase.include?("redacted=false")
-            send_response(200, "OK", @settings.to_hash)
-          else
-            send_response(200, "OK", redact_sensitive(@settings.to_hash))
-          end
+        return unauthorized_response unless authorized?
+        @logger.info("http socket responding to request for configuration settings")
+        if @http_query_string and @http_query_string.downcase.include?("redacted=false")
+          send_response(200, "OK", @settings.to_hash)
         else
-          @logger.warn("http socket refusing to serve unauthorized settings request")
-          @response.headers["WWW-Authenticate"] = 'Basic realm="Sensu Client Restricted Area"'
-          send_response(401, "Unauthorized", {
-            :response => "You must be authenticated using your http_options user and password settings"
-          })
+          send_response(200, "OK", redact_sensitive(@settings.to_hash))
         end
       end
 


### PR DESCRIPTION
## Description
Adds a `protect_all_endpoints` boolean flag to the `http_socket` settings as described in #1724, allowing for the other resource endpoints (`info` and `results`) to be protected by basic authorization along with `settings`.

Includes a one-liner fix for the response sent when a method is not allowed. Let me know if it's preferable to put this in a separate PR.

## Related Issue
#1724

## Motivation and Context
Extends the existing basic auth protection in a backwards-compatible manner to the other endpoints. It's useful with the /results endpoint in particular, in environments where selective processes should have the ability to relay check results.

## How Has This Been Tested?
Manually tested making requests without the option set, and with the boolean set to both true and false. Could use some pointers on writing the test spec - I didn't see an obvious way of overwriting the client settings from within the spec.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
