### PR TITLE
Client socket accepts multiple checks in one request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Features
+
+Client socket should be able to accept multiple checks in one request.
+This will improve the performance a lot if user needs to push lots of
+checks into sensu client through HTTP or TCP.
+
 ## 1.0.3 - 2017-08-25
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-### Features
-
-Client socket should be able to accept multiple checks in one request.
-This will improve the performance a lot if user needs to push lots of
-checks into sensu client through HTTP or TCP.
-
 ## 1.0.3 - 2017-08-25
 
 ### Fixes

--- a/lib/sensu/client/http_socket.rb
+++ b/lib/sensu/client/http_socket.rb
@@ -113,8 +113,14 @@ module Sensu
       def process_request_results
         if @http[:content_type] and @http[:content_type] == "application/json" and @http_content
           begin
-            check = Sensu::JSON::load(@http_content)
-            process_check_result(check)
+            object = Sensu::JSON::load(@http_content)
+            if object.instance_of? Array
+              for check in object do
+                process_check_result(check)
+              end
+            else
+              process_check_result(object)
+            end
             send_response(202, "OK", {:response => "ok"})
           rescue Sensu::JSON::ParseError, ArgumentError
             send_response(400, "Failed to parse JSON body", {:response => "Failed to parse JSON body"})

--- a/lib/sensu/client/socket.rb
+++ b/lib/sensu/client/socket.rb
@@ -123,9 +123,15 @@ module Sensu
       # @param [String] data to parse for a check result.
       def parse_check_result(data)
         begin
-          check = Sensu::JSON.load(data)
+          object = Sensu::JSON.load(data)
           cancel_watchdog
-          process_check_result(check)
+          if object.instance_of? Array
+            for check in object do
+              process_check_result(check)
+            end
+          else
+            process_check_result(object)
+          end
           respond("ok")
         rescue Sensu::JSON::ParseError, ArgumentError => error
           if @protocol == :tcp

--- a/spec/client/http_socket_spec.rb
+++ b/spec/client/http_socket_spec.rb
@@ -58,6 +58,9 @@ describe "Sensu::Client::HTTPSocket" do
           result = Sensu::JSON.load(payload)
           expect(result[:client]).to eq("i-424242")
           expect(result[:check][:name]).to eq("http")
+          expect(result[:check][:name]).to eq("http2")
+          expect(result[:check][:name]).to eq("http3")
+          end
           async_done
         end
         timer(1) do
@@ -66,9 +69,7 @@ describe "Sensu::Client::HTTPSocket" do
                                {:name => "http3", :output => "http3", :status => 2}]}
           http_request(3031, "/results", :post, options)do |http, body|
             len = options[:body].length-1
-            for i in (0..len) do
-              expect(http.response_header.status).to eq(202)
-            end
+            expect(http.response_header.status).to eq(202)
             expect(body).to eq({:response => "ok"})
           end
         end

--- a/spec/client/http_socket_spec.rb
+++ b/spec/client/http_socket_spec.rb
@@ -65,7 +65,10 @@ describe "Sensu::Client::HTTPSocket" do
                                {:name => "http2", :output => "http2", :status => 0},
                                {:name => "http3", :output => "http3", :status => 2}]}
           http_request(3031, "/results", :post, options)do |http, body|
-            expect(http.response_header.status).to eq(202)
+            len = options[:body].length-1
+            for i in (0..len) do
+              expect(http.response_header.status).to eq(202)
+            end
             expect(body).to eq({:response => "ok"})
           end
         end

--- a/spec/client/http_socket_spec.rb
+++ b/spec/client/http_socket_spec.rb
@@ -58,15 +58,12 @@ describe "Sensu::Client::HTTPSocket" do
           result = Sensu::JSON.load(payload)
           expect(result[:client]).to eq("i-424242")
           expect(result[:check][:name]).to eq("http")
-          expect(result[:check][:name]).to eq("http2")
-          expect(result[:check][:name]).to eq("http3")
-          end
           async_done
         end
         timer(1) do
           options = {:body => [{:name => "http", :output => "http", :status => 1},
-                               {:name => "http2", :output => "http2", :status => 0},
-                               {:name => "http3", :output => "http3", :status => 2}]}
+                               {:name => "http", :output => "http2", :status => 0},
+                               {:name => "http", :output => "http3", :status => 2}]}
           http_request(3031, "/results", :post, options)do |http, body|
             len = options[:body].length-1
             expect(http.response_header.status).to eq(202)

--- a/spec/client/socket_spec.rb
+++ b/spec/client/socket_spec.rb
@@ -161,8 +161,10 @@ describe Sensu::Client::Socket do
       checks = [{:name => "test1", :output => "good!"},
                 {:name => "test2", :output => "still good!"}]
       expect(subject).to receive(:cancel_watchdog)
-      expect(subject).to receive(:process_check_result).with(checks[0])
-      expect(subject).to receive(:process_check_result).with(checks[1])
+      len = checks.length-1
+      for i in (0..len) do
+        expect(subject).to receive(:process_check_result).with(checks[i])
+      end
       expect(subject).to receive(:respond).with("ok")
       subject.parse_check_result(json_check_data)
     end

--- a/spec/client/socket_spec.rb
+++ b/spec/client/socket_spec.rb
@@ -154,6 +154,19 @@ describe Sensu::Client::Socket do
       expect(subject).to receive(:respond).with("ok")
       subject.parse_check_result(json_check_data)
     end
+    
+    it "also accepts multiple check results" do
+      json_check_data = "[{\"name\": \"test1\", \"output\": \"good!\"},
+                          {\"name\": \"test2\", \"output\": \"still good!\"}]"
+      checks = [{:name => "test1", :output => "good!"},
+                {:name => "test2", :output => "still good!"}]
+      expect(subject).to receive(:cancel_watchdog)
+      expect(subject).to receive(:process_check_result).with(checks[0])
+      expect(subject).to receive(:process_check_result).with(checks[1])
+      expect(subject).to receive(:respond).with("ok")
+      subject.parse_check_result(json_check_data)
+    end
+    
   end
 
   describe "#process_data" do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Make sensu client can accept multiple checks through client sockets(HTTP and TCP)

## Description
<!--- Describe your changes in detail -->
If user needs to push lots of results through client socket in one request, it will improve the client socket performance a lot. 
This patch will allow the HTTP and TCP socket receive the data as array of checks.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
