### PR TITLE
Check Hooks

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -117,7 +117,13 @@ module Sensu
       # substituted with the associated client attribute values, via
       # `substitute_tokens()`. If there are unmatched check attribute
       # value tokens, the check hook will not be executed, instead the
-      # hook command output will be set to report the unmatched tokens.
+      # hook command output will be set to report the unmatched
+      # tokens. Hook commands may expect/read and utilize JSON
+      # serialized Sensu client and check data via STDIN, if the hook
+      # definition includes `"stdin": true` (default is `false`). A
+      # hook may have a configured execution timeout, e.g. `"timeout":
+      # 30`, if one is not specified, the timeout defaults to 60
+      # seconds.
       #
       # @param check [Hash]
       # @yield [check] callback/block called after executing the check
@@ -134,7 +140,7 @@ module Sensu
           started = Time.now.to_f
           hook[:executed] = started.to_i
           if unmatched_tokens.empty?
-            options = {:timeout => hook[:timeout]}
+            options = {:timeout => hook.fetch(:timeout, 60)}
             if hook[:stdin]
               options[:data] = Sensu::JSON.dump({
                 :client => @settings[:client],

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -113,7 +113,7 @@ module Sensu
       def execute_check_hook(check)
         @logger.debug("attempting to execute check hook", :check => check)
         severity = SEVERITIES[check[:status]] || "unknown"
-        hook = check[:hooks][check[:status]] || check[:hooks][severity]
+        hook = check[:hooks][check[:status]] || check[:hooks][severity.to_sym]
         if hook.nil? && check[:status] != 0
           hook = check[:hooks]["non-zero"]
         end

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -110,6 +110,16 @@ module Sensu
         [check[:source], check[:name]].compact.join(":")
       end
 
+      # Execute a check hook, capturing its output (STDOUT/ERR),
+      # exit status code, executed timestamp, and duration. This
+      # method determines which hook command to run by inspecting the
+      # check execution status. Check hook command tokens are
+      # substituted with the associated client attribute values, via
+      # `substitute_tokens()`. If there are unmatched check attribute
+      # value tokens, the check hook will not be executed, instead the
+      # hook command output will be set to report the unmatched tokens.
+      #
+      # @param check [Hash]
       def execute_check_hook(check)
         @logger.debug("attempting to execute check hook", :check => check)
         severity = SEVERITIES[check[:status]] || "unknown"

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -120,6 +120,8 @@ module Sensu
       # hook command output will be set to report the unmatched tokens.
       #
       # @param check [Hash]
+      # @yield [check] callback/block called after executing the check
+      #   hook (if any).
       def execute_check_hook(check)
         @logger.debug("attempting to execute check hook", :check => check)
         severity = SEVERITIES[check[:status]] || "unknown"

--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -113,7 +113,7 @@ module Sensu
       def execute_check_hook(check)
         @logger.debug("attempting to execute check hook", :check => check)
         severity = SEVERITIES[check[:status]] || "unknown"
-        hook = check[:hooks][check[:status]] || check[:hooks][severity.to_sym]
+        hook = check[:hooks][check[:status].to_s] || check[:hooks][severity.to_sym]
         if hook.nil? && check[:status] != 0
           hook = check[:hooks]["non-zero"]
         end

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.5"
 
 gem "sensu-json", "2.1.0"
 gem "sensu-logger", "1.2.1"
-gem "sensu-settings", "10.3.0"
+gem "sensu-settings", "10.4.0"
 gem "sensu-extension", "1.5.1"
 gem "sensu-extensions", "1.9.0"
 gem "sensu-transport", "7.0.2"

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.5"
 
 gem "sensu-json", "2.1.0"
 gem "sensu-logger", "1.2.1"
-gem "sensu-settings", "10.4.0"
+gem "sensu-settings", "10.5.0"
 gem "sensu-extension", "1.5.1"
 gem "sensu-extensions", "1.9.0"
 gem "sensu-transport", "7.0.2"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.5"
   s.add_dependency "sensu-json", "2.1.0"
   s.add_dependency "sensu-logger", "1.2.1"
-  s.add_dependency "sensu-settings", "10.4.0"
+  s.add_dependency "sensu-settings", "10.5.0"
   s.add_dependency "sensu-extension", "1.5.1"
   s.add_dependency "sensu-extensions", "1.9.0"
   s.add_dependency "sensu-transport", "7.0.2"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.5"
   s.add_dependency "sensu-json", "2.1.0"
   s.add_dependency "sensu-logger", "1.2.1"
-  s.add_dependency "sensu-settings", "10.3.0"
+  s.add_dependency "sensu-settings", "10.4.0"
   s.add_dependency "sensu-extension", "1.5.1"
   s.add_dependency "sensu-extensions", "1.9.0"
   s.add_dependency "sensu-transport", "7.0.2"

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -271,6 +271,23 @@ describe "Sensu::Client::Process" do
     end
   end
 
+  it "can execute a check hook with a timeout" do
+    async_wrapper do
+      check = check_template
+      check[:hooks] = {
+        :warning => {
+          :command => "sleep 10",
+          :timeout => 1
+        }
+      }
+      @client.execute_check_hook(check) do |check|
+        expect(check[:hooks][:warning][:output]).to eq("Execution timed out")
+        expect(check[:hooks][:warning][:status]).to eq(2)
+        async_done
+      end
+    end
+  end
+
   it "can execute a check command and a hook" do
     async_wrapper do
       result_queue do |payload|

--- a/spec/config.json
+++ b/spec/config.json
@@ -139,14 +139,14 @@
   },
   "checks": {
     "tokens": {
-      "command": "echo -n :::name::: :::nested.attribute::: && exit 2",
+      "command": "echo :::name::: :::nested.attribute::: && exit 2",
       "subscribers": [
         "test"
       ],
       "interval": 1
     },
     "standalone": {
-      "command": "echo -n foobar && exit 1",
+      "command": "echo foobar && exit 1",
       "standalone": true,
       "interval": 1,
       "ttl": 10,

--- a/spec/config.json
+++ b/spec/config.json
@@ -208,7 +208,7 @@
               "timeout": 5
           }
       },
-      "interval": 10
+      "interval": 1
     }
   },
   "client": {

--- a/spec/config.json
+++ b/spec/config.json
@@ -196,6 +196,19 @@
         "test"
       ],
       "cron": "* * * * *"
+    },
+    "hooked": {
+      "command": "echo FAIL && exit 1",
+      "subscribers": [
+        "test"
+      ],
+      "hooks": {
+          "warning": {
+              "command": "echo HOOKED",
+              "timeout": 5
+          }
+      },
+      "interval": 10
     }
   },
   "client": {

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -684,7 +684,7 @@ describe "Sensu::Server::Process" do
 
   it "can schedule check request publishing" do
     async_wrapper do
-      expected = ["tokens", "merger", "source", "cron"]
+      expected = ["tokens", "merger", "source", "cron", "hooked"]
       setup_transport do |transport|
         transport.subscribe(:fanout, "test") do |_, payload|
           check_request = Sensu::JSON.load(payload)


### PR DESCRIPTION
The Sensu client’s primary function is to execute check commands and publish their results for processing, allowing a Sensu server to take the appropriate actions. The practice of using Sensu for automated data gathering for incident triage continues to gain traction amongst Sensu users. Although this practice is achievable, Sensu does not currently make it easy, as all actions must be orchestrated by a Sensu server.

This pull request introduce check hooks, commands run by the Sensu client in response to the result of the check command execution. The Sensu client will execute the appropriate configured hook command, depending on the check execution status (e.g. 1). Valid hook names include (in order of precedence): "1"-"255", "ok", "warning", "critical", "unknown", and "non-zero". The check hook command output, status, executed timestamp, and duration are captured and published in the check result.

Example check hook configuration:

``` json
{
  "checks": {
    "my_check": {
      "command": "echo WARNING && exit 1",
      "...": "...",
      "hooks": {
        "ok": "echo ALL IS WELL",
        "warning": "echo DANGER WILL ROBINSON!",
        "critical": "ps aux"
      }
    }
  }
}
```

Example check result hook data:

```
{
  "hooks": {
    "warning": {
      "command": "echo HOOKED",
      "timeout": 5,
      "output": "HOOKED\n",
      "status": 0,
      "executed": 1506049908,
      "duration": 0.004
    }
  }
}
```

Closes https://github.com/sensu/sensu/issues/1680