### PR TITLE
Configurable check output truncation

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.5"
 
 gem "sensu-json", "2.1.0"
 gem "sensu-logger", "1.2.1"
-gem "sensu-settings", "10.3.0"
+gem "sensu-settings", "10.6.0"
 gem "sensu-extension", "1.5.1"
 gem "sensu-extensions", "1.9.0"
 gem "sensu-transport", "7.0.2"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.5"
   s.add_dependency "sensu-json", "2.1.0"
   s.add_dependency "sensu-logger", "1.2.1"
-  s.add_dependency "sensu-settings", "10.3.0"
+  s.add_dependency "sensu-settings", "10.6.0"
   s.add_dependency "sensu-extension", "1.5.1"
   s.add_dependency "sensu-extensions", "1.9.0"
   s.add_dependency "sensu-transport", "7.0.2"

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -489,6 +489,10 @@ describe "Sensu::Server::Process" do
             check[:output] = "foo\nbar\nbaz"
             truncated = @server.truncate_check_output(check)
             expect(truncated[:output]).to eq("foo\nbar\nbaz")
+            check[:truncate_output] = true
+            truncated = @server.truncate_check_output(check)
+            expect(truncated[:output]).to eq("foo\n...")
+            check.delete(:truncate_output)
             check[:type] = "metric"
             truncated = @server.truncate_check_output(check)
             expect(truncated[:output]).to eq("foo\n...")
@@ -504,6 +508,12 @@ describe "Sensu::Server::Process" do
             check[:output] = rand(36**256).to_s(36).rjust(256, '0')
             truncated = @server.truncate_check_output(check)
             expect(truncated[:output]).to eq(check[:output][0..255] + "\n...")
+            check[:truncate_output_length] = 10
+            truncated = @server.truncate_check_output(check)
+            expect(truncated[:output]).to eq(check[:output][0..10] + "\n...")
+            check[:truncate_output] = false
+            truncated = @server.truncate_check_output(check)
+            expect(truncated[:output]).to eq(check[:output])
             client = client_template
             redis.set("client:i-424242", Sensu::JSON.dump(client)) do
               result = result_template


### PR DESCRIPTION
This pull-requests makes check output truncation, prior to Redis storage, configurable via check definition attributes, `"truncate_output": false`, and `"truncate_output_length": 1024`. These changes were described in https://github.com/sensu/sensu/issues/1074#issuecomment-328638425

Closes https://github.com/sensu/sensu/issues/1074