### PR TITLE
Check stdin

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -187,7 +187,14 @@ module Sensu
           started = Time.now.to_f
           check[:executed] = started.to_i
           if unmatched_tokens.empty?
-            Spawn.process(substituted[:command], :timeout => check[:timeout]) do |output, status|
+            options = {:timeout => check[:timeout]}
+            if check[:stdin]
+              options[:data] = Sensu::JSON.dump({
+                :client => @settings[:client],
+                :check => check
+              })
+            end
+            Spawn.process(substituted[:command], options) do |output, status|
               check[:duration] = ("%.3f" % (Time.now.to_f - started)).to_f
               check[:output] = output
               check[:status] = status

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.5"
 
 gem "sensu-json", "2.1.0"
 gem "sensu-logger", "1.2.1"
-gem "sensu-settings", "10.7.0"
+gem "sensu-settings", "10.8.0"
 gem "sensu-extension", "1.5.1"
 gem "sensu-extensions", "1.9.0"
 gem "sensu-transport", "7.0.2"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.5"
   s.add_dependency "sensu-json", "2.1.0"
   s.add_dependency "sensu-logger", "1.2.1"
-  s.add_dependency "sensu-settings", "10.7.0"
+  s.add_dependency "sensu-settings", "10.8.0"
   s.add_dependency "sensu-extension", "1.5.1"
   s.add_dependency "sensu-extensions", "1.9.0"
   s.add_dependency "sensu-transport", "7.0.2"

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -110,6 +110,28 @@ describe "Sensu::Client::Process" do
     end
   end
 
+  it "can execute a check command with stdin" do
+    async_wrapper do
+      result_queue do |payload|
+        result = Sensu::JSON.load(payload)
+        expect(result[:client]).to eq("i-424242")
+        output = Sensu::JSON.load(result[:check][:output])
+        expect(output[:client][:name]).to eq("i-424242")
+        expect(output[:check][:name]).to eq("test")
+        expect(result[:check]).to have_key(:executed)
+        async_done
+      end
+      timer(0.5) do
+        @client.setup_transport do
+          check = check_template
+          check[:command] = "cat"
+          check[:stdin] = true
+          @client.execute_check_command(check)
+        end
+      end
+    end
+  end
+
   it "can substitute tokens in a check definition" do
     check = check_template
     check[:command] = "echo :::nested.attribute:::"


### PR DESCRIPTION
A boolean check definition attribute, `stdin`, when set to `true` instructs the Sensu client to write JSON serialized Sensu client and check data to the check process STDIN. This attribute cannot be used with existing Sensu check plugins, nor Nagios plugins etc, as the Sensu client will wait indefinitely for the check process to read and close STDIN.