### PR TITLE
Proxy Check Request splay (rate limiting*)

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.5"
 
 gem "sensu-json", "2.1.0"
 gem "sensu-logger", "1.2.1"
-gem "sensu-settings", "10.8.0"
+gem "sensu-settings", "10.9.0"
 gem "sensu-extension", "1.5.1"
 gem "sensu-extensions", "1.9.0"
 gem "sensu-transport", "7.0.2"

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -834,7 +834,14 @@ module Sensu
         client_count = clients.length
         splay = 0
         if check[:proxy_requests][:splay]
-          splay = check[:interval] * 0.9 / client_count
+          interval = check[:interval]
+          if check[:cron]
+            interval = determine_check_cron_time(check)
+          end
+          unless interval.nil?
+            splay_coverage = check[:proxy_requests].fetch(:splay_coverage, 90)
+            splay = interval * (splay_coverage / 100.0) / client_count
+          end
         end
         splay_timer = 0
         clients.each do |client|

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.5"
   s.add_dependency "sensu-json", "2.1.0"
   s.add_dependency "sensu-logger", "1.2.1"
-  s.add_dependency "sensu-settings", "10.8.0"
+  s.add_dependency "sensu-settings", "10.9.0"
   s.add_dependency "sensu-extension", "1.5.1"
   s.add_dependency "sensu-extensions", "1.9.0"
   s.add_dependency "sensu-transport", "7.0.2"

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -117,7 +117,8 @@ module Helpers
       :command => "echo WARNING && exit 1",
       :output => "WARNING",
       :status => 1,
-      :executed => 1363224805
+      :executed => 1363224805,
+      :interval => 60
     }
   end
 

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -674,7 +674,7 @@ describe "Sensu::Server::Process" do
                       :subscriptions => "eval: value.include?('test')"
                     }
                   }
-                  @server.publish_proxy_check_requests(check)
+                  @server.create_proxy_check_requests(check)
                 end
               end
             end


### PR DESCRIPTION
This pull request accomplishes two things, adding proxy check request splayed publishing, and improved proxy check request performance.

This pull request adds two new check definition attributes, within the `proxy_requests` scope, `splay` (boolean) and `splay_coverage` (integer percentage, defaults to `90`).

Users can now splay proxy check requests, evenly, over a window of time, determined by the check interval and a configurable splay coverage percentage. For example, splay proxy check requests over 60s * 90%, 54s, leaving 6s for the last proxy check execution before the the next round of proxy check requests for the same check.

Closes https://github.com/sensu/sensu/issues/1650