### PR TITLE
Sensu server configurable keepalives attributes

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.5"
 
 gem "sensu-json", "2.1.0"
 gem "sensu-logger", "1.2.1"
-gem "sensu-settings", "10.9.0"
+gem "sensu-settings", "10.10.0"
 gem "sensu-extension", "1.5.1"
 gem "sensu-extensions", "1.9.0"
 gem "sensu-transport", "7.0.2"

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -1065,6 +1065,9 @@ module Sensu
         if @settings.handler_exists?(:keepalive)
           check[:handler] = "keepalive"
         end
+        if @settings[:sensu][:keepalives]
+          check = deep_merge(check, @settings[:sensu][:keepalives])
+        end
         if client.has_key?(:keepalive)
           check = deep_merge(check, client[:keepalive])
         end

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.5"
   s.add_dependency "sensu-json", "2.1.0"
   s.add_dependency "sensu-logger", "1.2.1"
-  s.add_dependency "sensu-settings", "10.9.0"
+  s.add_dependency "sensu-settings", "10.10.0"
   s.add_dependency "sensu-extension", "1.5.1"
   s.add_dependency "sensu-extensions", "1.9.0"
   s.add_dependency "sensu-transport", "7.0.2"


### PR DESCRIPTION
This pull requests makes the Sensu client keepalive attribute values configurable on the Sensu server. Why? It makes keepalive configuration easier, particularly when configuration management is not used to manage Sensu's distributed configuration. These changes are fully backwards compatible, they do not impact existing behaviour.

For example:

```
{
  "sensu": {
    "spawn": {
      "...": "..."
    },
    "keepalives": {
      "thresholds": {
        "warning": 60,
        "critical": 80
      },
      "handlers": ["slack", "pagerduty"]
    }
  }
}
```