### PR TITLE
Fixed Check TTL member removal

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -1184,7 +1184,7 @@ module Sensu
                 end
               end
             else
-              @redis.srem("ttl", result_key)
+              @redis.srem("ttl", ttl_keys[index])
             end
           end
           yield


### PR DESCRIPTION
Closes https://github.com/sensu/sensu/issues/1762

I was able to reproduce the issue reported at https://github.com/sensu/sensu/issues/1762, check TTL member removal after deleting the associated result causes the uncaught exception, due to the undefined variable "result_key". This pull request replaces it with `ttl_keys[index]`. I have confirmed  that this fix works and I am no longer able to reproduce #1762.