### PR TITLE
Fix Check Hooks

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -131,9 +131,9 @@ module Sensu
       def execute_check_hook(check)
         @logger.debug("attempting to execute check hook", :check => check)
         severity = SEVERITIES[check[:status]] || "unknown"
-        hook = check[:hooks][check[:status].to_s] || check[:hooks][severity.to_sym]
+        hook = check[:hooks][check[:status].to_s.to_sym] || check[:hooks][severity.to_sym]
         if hook.nil? && check[:status] != 0
-          hook = check[:hooks]["non-zero"]
+          hook = check[:hooks]["non-zero".to_sym]
         end
         if hook
           command, unmatched_tokens = substitute_tokens(hook[:command].dup, @settings[:client])

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -223,7 +223,7 @@ describe "Sensu::Client::Process" do
     async_wrapper do
       check = check_template
       check[:hooks] = {
-        "1" => {
+        :"1" => {
           :command => "echo STATUS"
         },
         :warning => {
@@ -231,8 +231,8 @@ describe "Sensu::Client::Process" do
         }
       }
       @client.execute_check_hook(check) do |check|
-        expect(check[:hooks]["1"][:output]).to eq("STATUS\n")
-        expect(check[:hooks]["1"][:status]).to eq(0)
+        expect(check[:hooks][:"1"][:output]).to eq("STATUS\n")
+        expect(check[:hooks][:"1"][:status]).to eq(0)
         expect(check[:hooks][:warning]).to_not have_key(:output)
         async_done
       end
@@ -246,13 +246,13 @@ describe "Sensu::Client::Process" do
         :ok => {
           :command => "echo OK"
         },
-        "non-zero" => {
+        :"non-zero" => {
           :command => "echo NON-ZERO"
         }
       }
       @client.execute_check_hook(check) do |check|
-        expect(check[:hooks]["non-zero"][:output]).to eq("NON-ZERO\n")
-        expect(check[:hooks]["non-zero"][:status]).to eq(0)
+        expect(check[:hooks][:"non-zero"][:output]).to eq("NON-ZERO\n")
+        expect(check[:hooks][:"non-zero"][:status]).to eq(0)
         async_done
       end
     end


### PR DESCRIPTION
Sensu check request JSON parsing produces a hash with symbolized keys, therefor symbolized keys must be used for hooks. This pull-request fixes hooks named after status codes, e.g. `1`, and `non-zero`.

Previously, if a Sensu client had a local check definition, the settings loader provided both symbol and string keys and hooks worked. Hooks with severity names, e.g. `warning`, also worked, because Sensu was converting them to symbols.

Closes https://github.com/sensu/sensu/issues/1773