### PR TITLE
Scheduled maintenance event silencing

### DIFF
--- a/lib/sensu/api/routes/silenced.rb
+++ b/lib/sensu/api/routes/silenced.rb
@@ -77,7 +77,7 @@ module Sensu
                   if data[:expire]
                     expire = data[:expire]
                     expire += begin_timestamp - timestamp
-                     @redis.expire(silenced_key, expire) do
+                    @redis.expire(silenced_key, expire) do
                       created!
                     end
                   else

--- a/lib/sensu/api/routes/silenced.rb
+++ b/lib/sensu/api/routes/silenced.rb
@@ -60,13 +60,14 @@ module Sensu
               check = data.fetch(:check, "*")
               silenced_id = "#{subscription}:#{check}"
               timestamp = Time.now.to_i
+              begin_timestamp = data.fetch(:begin, timestamp)
               silenced_info = {
                 :id => silenced_id,
                 :subscription => data[:subscription],
                 :check => data[:check],
                 :reason => data[:reason],
                 :creator => data[:creator],
-                :begin => data[:begin],
+                :begin => begin_timestamp,
                 :expire_on_resolve => data.fetch(:expire_on_resolve, false),
                 :timestamp => timestamp
               }
@@ -75,10 +76,8 @@ module Sensu
                 @redis.sadd("silenced", silenced_key) do
                   if data[:expire]
                     expire = data[:expire]
-                    if data[:begin] && data[:begin] > timestamp
-                      expire += data[:begin] - timestamp
-                    end
-                    @redis.expire(silenced_key, expire) do
+                    expire += begin_timestamp - timestamp
+                     @redis.expire(silenced_key, expire) do
                       created!
                     end
                   else

--- a/lib/sensu/api/routes/silenced.rb
+++ b/lib/sensu/api/routes/silenced.rb
@@ -48,6 +48,7 @@ module Sensu
           rules = {
             :subscription => {:type => String, :nil_ok => true, :regex => /\A[\w\.\-\:]+\z/},
             :check => {:type => String, :nil_ok => true, :regex => /\A[\w\.-]+\z/},
+            :begin => {:type => Integer, :nil_ok => true},
             :expire => {:type => Integer, :nil_ok => true},
             :reason => {:type => String, :nil_ok => true},
             :creator => {:type => String, :nil_ok => true},
@@ -64,6 +65,7 @@ module Sensu
                 :check => data[:check],
                 :reason => data[:reason],
                 :creator => data[:creator],
+                :begin => data[:begin],
                 :expire_on_resolve => data.fetch(:expire_on_resolve, false),
                 :timestamp => Time.now.to_i
               }

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -485,7 +485,7 @@ module Sensu
                 silenced_key = "silence:#{silenced_info[:id]}"
                 @redis.srem("silenced", silenced_key)
                 @redis.del(silenced_key)
-              else
+              elsif silenced_info[:begin].nil? || silenced_info[:begin] <= Time.now.to_i
                 event[:silenced_by] << silenced_info[:id]
               end
             end

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -1465,6 +1465,7 @@ describe "Sensu::API::Process" do
           expect(silenced_info[:id]).to eq("test:*")
           expect(silenced_info[:subscription]).to eq("test")
           expect(silenced_info[:check]).to be_nil
+          expect(silenced_info[:begin]).to be_within(10).of(Time.now.to_i)
           expect(silenced_info[:reason]).to be_nil
           expect(silenced_info[:creator]).to be_nil
           expect(silenced_info[:expire_on_resolve]).to eq(false)
@@ -1489,6 +1490,7 @@ describe "Sensu::API::Process" do
           expect(silenced_info[:id]).to eq("*:test")
           expect(silenced_info[:subscription]).to be_nil
           expect(silenced_info[:check]).to eq("test")
+          expect(silenced_info[:begin]).to be_within(10).of(Time.now.to_i)
           expect(silenced_info[:reason]).to be_nil
           expect(silenced_info[:creator]).to be_nil
           expect(silenced_info[:expire_on_resolve]).to eq(false)
@@ -1518,12 +1520,48 @@ describe "Sensu::API::Process" do
           expect(silenced_info[:id]).to eq("test:test")
           expect(silenced_info[:subscription]).to eq("test")
           expect(silenced_info[:check]).to eq("test")
+          expect(silenced_info[:begin]).to be_within(10).of(Time.now.to_i)
           expect(silenced_info[:reason]).to eq("testing")
           expect(silenced_info[:creator]).to eq("rspec")
           expect(silenced_info[:expire_on_resolve]).to eq(true)
           expect(silenced_info[:timestamp]).to be_within(10).of(Time.now.to_i)
           redis.ttl("silence:test:test") do |ttl|
             expect(ttl).to be_within(10).of(3600)
+            async_done
+          end
+        end
+      end
+    end
+  end
+
+  it "can create a silenced registry entry with a begin time that expires" do
+    api_test do
+      begin_timestamp = Time.now.to_i + 60
+      options = {
+        :body => {
+          :subscription => "test",
+          :check => "test",
+          :begin => begin_timestamp,
+          :expire => 3600,
+          :reason => "testing",
+          :creator => "rspec",
+          :expire_on_resolve => true
+        }
+      }
+      http_request(4567, "/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(201)
+        redis.get("silence:test:test") do |silenced_info_json|
+          silenced_info = Sensu::JSON.load(silenced_info_json)
+          expect(silenced_info[:id]).to eq("test:test")
+          expect(silenced_info[:subscription]).to eq("test")
+          expect(silenced_info[:check]).to eq("test")
+          expect(silenced_info[:begin]).to eq(begin_timestamp)
+          expect(silenced_info[:reason]).to eq("testing")
+          expect(silenced_info[:creator]).to eq("rspec")
+          expect(silenced_info[:expire_on_resolve]).to eq(true)
+          expect(silenced_info[:timestamp]).to be_within(10).of(Time.now.to_i)
+          redis.ttl("silence:test:test") do |ttl|
+            expect(ttl).to be_within(10).of(3660)
             async_done
           end
         end
@@ -1676,6 +1714,22 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can not create a silenced registry entry with an invalid begin time" do
+    api_test do
+      options = {
+        :body => {
+          :subscription => "test",
+          :check => "test",
+          :begin => Time.now.to_i.to_s
+        }
+      }
+      http_request(4567, "/silenced", :post, options) do |http, body|
+        expect(http.response_header.status).to eq(400)
+        async_done
+      end
+    end
+  end
+
   it "can provide the silenced registry" do
     api_test do
       options = {
@@ -1696,6 +1750,7 @@ describe "Sensu::API::Process" do
           expect(silenced_info[:id]).to eq("test:test")
           expect(silenced_info[:subscription]).to eq("test")
           expect(silenced_info[:check]).to eq("test")
+          expect(silenced_info[:begin]).to be_within(10).of(Time.now.to_i)
           expect(silenced_info[:expire]).to be_within(10).of(3600)
           expect(silenced_info[:timestamp]).to be_within(10).of(Time.now.to_i)
           http_request(4567, "/silenced/subscriptions/test") do |http, body|

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -1465,7 +1465,7 @@ describe "Sensu::API::Process" do
           expect(silenced_info[:id]).to eq("test:*")
           expect(silenced_info[:subscription]).to eq("test")
           expect(silenced_info[:check]).to be_nil
-          expect(silenced_info[:begin]).to be_within(10).of(Time.now.to_i)
+          expect(silenced_info[:begin]).to be_nil
           expect(silenced_info[:reason]).to be_nil
           expect(silenced_info[:creator]).to be_nil
           expect(silenced_info[:expire_on_resolve]).to eq(false)
@@ -1490,7 +1490,7 @@ describe "Sensu::API::Process" do
           expect(silenced_info[:id]).to eq("*:test")
           expect(silenced_info[:subscription]).to be_nil
           expect(silenced_info[:check]).to eq("test")
-          expect(silenced_info[:begin]).to be_within(10).of(Time.now.to_i)
+          expect(silenced_info[:begin]).to be_nil
           expect(silenced_info[:reason]).to be_nil
           expect(silenced_info[:creator]).to be_nil
           expect(silenced_info[:expire_on_resolve]).to eq(false)
@@ -1520,7 +1520,7 @@ describe "Sensu::API::Process" do
           expect(silenced_info[:id]).to eq("test:test")
           expect(silenced_info[:subscription]).to eq("test")
           expect(silenced_info[:check]).to eq("test")
-          expect(silenced_info[:begin]).to be_within(10).of(Time.now.to_i)
+          expect(silenced_info[:begin]).to be_nil
           expect(silenced_info[:reason]).to eq("testing")
           expect(silenced_info[:creator]).to eq("rspec")
           expect(silenced_info[:expire_on_resolve]).to eq(true)
@@ -1750,7 +1750,7 @@ describe "Sensu::API::Process" do
           expect(silenced_info[:id]).to eq("test:test")
           expect(silenced_info[:subscription]).to eq("test")
           expect(silenced_info[:check]).to eq("test")
-          expect(silenced_info[:begin]).to be_within(10).of(Time.now.to_i)
+          expect(silenced_info[:begin]).to be_nil
           expect(silenced_info[:expire]).to be_within(10).of(3600)
           expect(silenced_info[:timestamp]).to be_within(10).of(Time.now.to_i)
           http_request(4567, "/silenced/subscriptions/test") do |http, body|


### PR DESCRIPTION
Scheduled maintenance. Sensu currently gives users the ability to silence a check and/or client subscriptions, stopping related Sensu events from being handled (e.g. no notifications). This pull request adds the ability to silence a check and/or client subscriptions at a predetermined time (`begin` epoch timestamp), enabling users to silence events for scheduled maintenance windows in advance.