### PR TITLE
Redact also deep_diff elements

### DIFF
--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -112,7 +112,15 @@ module Sensu
           hash[key] = redact_sensitive(value, keys)
         elsif value.is_a?(Array)
           hash[key] = value.map do |item|
-            item.is_a?(Hash) ? redact_sensitive(item, keys) : item
+            if item.is_a?(Hash)
+              redact_sensitive(item, keys)
+            elsif item.is_a?(Array)
+               item.map do |ytem|
+                 ytem.is_a?(Hash) ? redact_sensitive(ytem, keys) : ytem
+               end
+            else
+              item
+            end
           end
         end
       end


### PR DESCRIPTION
This patch makes redact_sensitive to dive one level deeper, so that also
item created by sensu-settings/lib/sensu/settings/loader/deep_diff is redacted

Closes #1804.

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
  note: redact_sensitive tests already contains tests for diff values. Not sure why they did not fail before TBH.
- [ ] All new and existing tests passed.
  note: most of the test timed out in my local environment, but the utilities tests are passing:
  [para@sanitarium sensu]$ rspec spec/utilities_spec.rb 
  ..........
  Finished in 0.52257 seconds (files took 0.22156 seconds to load)
  10 examples, 0 failures

