### PR TITLE
Make redact_sensitive more versatile

### DIFF
--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -101,7 +101,9 @@ describe "Sensu::Utilities" do
         :password => "bar"
       },
       :diff_one => [nil, {:secret => "baz"}],
-      :diff_two => [{:secret => "baz"}, {:secret => "qux"}]
+      :diff_two => [{:secret => "baz"}, {:secret => "qux"}],
+      :diff_three => [[{:secret => "jack"}], [{:secret => "jill"}]],
+      :nested_str_array => [["one", "two"]]
     }
     redacted = redact_sensitive(hash)
     expect(redacted[:one]).to eq(1)
@@ -110,6 +112,9 @@ describe "Sensu::Utilities" do
     expect(redacted[:diff_one][1][:secret]).to eq("REDACTED")
     expect(redacted[:diff_two][0][:secret]).to eq("REDACTED")
     expect(redacted[:diff_two][1][:secret]).to eq("REDACTED")
+    expect(redacted[:diff_three][0][0][:secret]).to eq("REDACTED")
+    expect(redacted[:diff_three][1][0][:secret]).to eq("REDACTED")
+    expect(redacted[:nested_str_array]).to eq([["one", "two"]])
   end
 
   it "can substitute dot notation tokens" do


### PR DESCRIPTION
## Description
This PR fixes #1804 by making `redact_sensitive` accept any object for the first parameter. If the object is a Hash or Array, it can recurse through to make sure any sensitive keys are redacted.

## Related Issue
Fixes #1804 

## Motivation and Context
See #1804 

## How Has This Been Tested?
Wrote a new test to cover hashes nested within an array which is nested within another array. Utility tests failed with code currently on master - tests pass with code in this PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
