### PR TITLE
Client socket "enabled" validation and fix

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -464,10 +464,9 @@ module Sensu
       # elsewhere, eg. `close_sockets()`.
       def setup_json_socket
         options = @settings[:client][:socket] || Hash.new
-        options[:enabled] ||= true
         options[:bind] ||= "127.0.0.1"
         options[:port] ||= 3030
-        if options[:enabled]
+        unless options[:enabled] == false
           @logger.debug("binding client tcp and udp sockets", :options => options)
           @sockets << EM::start_server(options[:bind], options[:port], Socket) do |socket|
             socket.logger = @logger
@@ -506,6 +505,8 @@ module Sensu
             socket.settings = @settings
             socket.transport = @transport
           end
+        else
+          @logger.info("client http socket disabled per configuration")
         end
       end
 

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.5"
 
 gem "sensu-json", "2.1.0"
 gem "sensu-logger", "1.2.1"
-gem "sensu-settings", "10.12.0"
+gem "sensu-settings", "10.13.0"
 gem "sensu-extension", "1.5.1"
 gem "sensu-extensions", "1.9.0"
 gem "sensu-transport", "7.0.2"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.5"
   s.add_dependency "sensu-json", "2.1.0"
   s.add_dependency "sensu-logger", "1.2.1"
-  s.add_dependency "sensu-settings", "10.12.0"
+  s.add_dependency "sensu-settings", "10.13.0"
   s.add_dependency "sensu-extension", "1.5.1"
   s.add_dependency "sensu-extensions", "1.9.0"
   s.add_dependency "sensu-transport", "7.0.2"


### PR DESCRIPTION
This PR updates the version of sensu-settings to 10.13.0, which supports Sensu client socket "enabled" option validation (must be a boolean if set). This PR also fixes the use of "enabled", when set to `false`.