### PR TITLE
Add Redis TLS support

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -9,7 +9,7 @@ gem "sensu-extension", "1.5.2"
 gem "sensu-extensions", "1.9.1"
 gem "sensu-transport", "7.0.3"
 gem "sensu-spawn", "2.2.2"
-gem "sensu-redis", "2.2.1"
+gem "sensu-redis", "2.3.0"
 
 require "time"
 require "uri"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sensu-extensions", "1.9.1"
   s.add_dependency "sensu-transport", "7.0.3"
   s.add_dependency "sensu-spawn", "2.2.2"
-  s.add_dependency "sensu-redis", "2.2.1"
+  s.add_dependency "sensu-redis", "2.3.0"
   s.add_dependency "em-http-server", "0.1.8"
   s.add_dependency "parse-cron", "0.1.4"
 


### PR DESCRIPTION
Use sensu-redis 2.3.0 which adds Redis TLS support (https://github.com/sensu/sensu-redis/pull/20)

Signed-off-by: Sean Porter <portertech@gmail.com>