### PR TITLE
Sensu call-home (Tessen)

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -1432,7 +1432,7 @@ module Sensu
             }
           )
           tessen = @settings[:tessen] || {}
-          tessen_enabled = tessen.fetch(:enabled, true)
+          tessen_enabled = tessen.fetch(:enabled, false)
           info = {
             :id => server_id,
             :hostname => system_hostname,

--- a/lib/sensu/server/tessen.rb
+++ b/lib/sensu/server/tessen.rb
@@ -70,15 +70,15 @@ module Sensu
         get_install_id do |install_id|
           get_client_count do |client_count|
             get_server_count do |server_count|
-              token = @options.fetch(:token, "")
-              type, version = get_version_info
+              identity_key = @options.fetch(:identity_key, "")
+              flavour, version = get_version_info
               timestamp = Time.now.to_i
               data = {
-                :token => token,
+                :tessen_identity_key => identity_key,
                 :install => {
                   :id => install_id,
-                  :type => type,
-                  :version => version
+                  :sensu_flavour => flavour,
+                  :sensu_version => version
                 },
                 :metrics => {
                   :points => [

--- a/lib/sensu/server/tessen.rb
+++ b/lib/sensu/server/tessen.rb
@@ -1,0 +1,165 @@
+require "em-http-request"
+require "sensu/constants"
+
+module Sensu
+  module Server
+    class Tessen
+      attr_accessor :settings, :logger, :redis, :options
+      attr_reader :timers
+
+      # Create a new instance of Tessen. The instance variable
+      # `@timers` is use to track EventMachine timers for
+      # stopping/shutdown.
+      #
+      # @param options [Hash] containing the Sensu server Settings,
+      #   Logger, and Redis connection.
+      def initialize(options={})
+        @timers = []
+        @settings = options[:settings]
+        @logger = options[:logger]
+        @redis = options[:redis]
+        @options = @settings.to_hash.fetch(:tessen, {})
+      end
+
+      # Determine if Tessen is enabled (opt-out).
+      #
+      # @return [TrueClass, FalseClass]
+      def enabled?
+        @options[:enabled] != false
+      end
+
+      # Run Tessen, scheduling data reports (every 6h).
+      def run
+        schedule_data_reports
+      end
+
+      # Stop Tessen, cancelling and clearing timers.
+      def stop
+        @timers.each do |timer|
+          timer.cancel
+        end
+        @timers.clear
+      end
+
+      # Schedule data reports, sending data to the Tessen service
+      # immediately and then every 6 hours after that.
+      def schedule_data_reports
+        note = "this data helps inform the sensu team about installations"
+        note << " - you can choose to opt-out via configuration: {\"tessen\": {\"enabled\": false}}"
+        @logger.info("sending anonymized data to the tessen call-home service", :note => note)
+        send_data
+        @timers << EM::PeriodicTimer.new(21600) do
+          send_data
+        end
+      end
+
+      # Send data to the Tessen service.
+      def send_data(&block)
+        create_data do |data|
+          tessen_api_request(data, &block)
+        end
+      end
+
+      # Create data to be sent to the Tessen service.
+      #
+      # @return [Hash]
+      def create_data
+        get_install_id do |install_id|
+          get_client_count do |client_count|
+            get_server_count do |server_count|
+              token = @options.fetch(:token, "")
+              type, version = get_version_info
+              timestamp = Time.now.to_i
+              data = {
+                :token => token,
+                :install => {
+                  :id => install_id,
+                  :type => type,
+                  :version => version
+                },
+                :metrics => {
+                  :points => [
+                    {
+                      :name => "client_count",
+                      :value => client_count,
+                      :timestamp => timestamp
+                    },
+                    {
+                      :name => "server_count",
+                      :value => server_count,
+                      :timestamp => timestamp
+                    }
+                  ]
+                }
+              }
+              yield data
+            end
+          end
+        end
+      end
+
+      # Get the Sensu installation ID. The ID is randomly generated
+      # and stored in Redis. This ID provides context and allows
+      # multiple Sensu servers to report data for the same installation.
+      def get_install_id
+        @redis.setnx("tessen:install_id", rand(36**12).to_s(36)) do |created|
+          @redis.get("tessen:install_id") do |install_id|
+            yield install_id
+          end
+        end
+      end
+
+      # Get the Sensu client count for the installation. This count
+      # currently includes proxy clients.
+      #
+      # @yield [count]
+      # @yieldparam [Integer] client count
+      def get_client_count
+        @redis.scard("clients") do |count|
+          yield count.to_i
+        end
+      end
+
+      # Get the Sensu server count for the installation.
+      #
+      # @yield [count]
+      # @yieldparam [Integer] server count
+      def get_server_count
+        @redis.scard("servers") do |count|
+          yield count.to_i
+        end
+      end
+
+      # Get the Sensu version info for the local Sensu service.
+      def get_version_info
+        if defined?(Sensu::Enterprise::VERSION)
+          ["enterprise", Sensu::Enterprise::VERSION]
+        else
+          ["core", Sensu::VERSION]
+        end
+      end
+
+      # Make a Tessen service API request.
+      #
+      # @param data [Hash]
+      def tessen_api_request(data)
+        @logger.debug("sending data to the tessen call-home service", {
+          :data => data,
+          :options => @options
+        })
+        connection = {}
+        connection[:proxy] = @options[:proxy] if @options[:proxy]
+        post_options = {:body => Sensu::JSON.dump(data)}
+        http = EM::HttpRequest.new("https://tessen.sensu.io/v1/data", connection).post(post_options)
+        http.callback do
+          @logger.debug("tessen call-home service response", :status => http.response_header.status)
+          yield if block_given?
+        end
+        http.errback do
+          @logger.debug("tessen call-home service error", :error => http.error)
+          yield if block_given?
+        end
+      end
+    end
+  end
+end

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "em-http-request", "~> 1.1"
   s.add_development_dependency "addressable", "2.3.8"
+  s.add_development_dependency "webmock", "3.3.0"
 
   s.files         = Dir.glob("{exe,lib}/**/*") + %w[sensu.gemspec README.md CHANGELOG.md MIT-LICENSE.txt]
   s.executables   = s.files.grep(%r{^exe/}) { |file| File.basename(file) }

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -3,6 +3,9 @@ require "eventmachine"
 require "em-http-request"
 require "securerandom"
 require "sensu/json"
+require "webmock/rspec"
+
+WebMock.allow_net_connect!
 
 module Helpers
   def setup_options

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -1081,6 +1081,7 @@ describe "Sensu::Server::Process" do
                 expect(server[:tasks]).to be_kind_of(Array)
                 expect(server[:sensu][:version]).to eq(Sensu::VERSION)
                 expect(server[:sensu][:settings][:hexdigest]).to be_kind_of(String)
+                expect(server[:tessen][:enabled]).to eq(true)
                 expect(server[:timestamp]).to be_within(5).of(Time.now.to_i)
                 async_done
               end

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -1081,7 +1081,7 @@ describe "Sensu::Server::Process" do
                 expect(server[:tasks]).to be_kind_of(Array)
                 expect(server[:sensu][:version]).to eq(Sensu::VERSION)
                 expect(server[:sensu][:settings][:hexdigest]).to be_kind_of(String)
-                expect(server[:tessen][:enabled]).to eq(true)
+                expect(server[:tessen][:enabled]).to eq(false)
                 expect(server[:timestamp]).to be_within(5).of(Time.now.to_i)
                 async_done
               end

--- a/spec/server/tessen_spec.rb
+++ b/spec/server/tessen_spec.rb
@@ -26,9 +26,9 @@ describe "Sensu::Server::Tessen" do
   end
 
   it "can determine if its enabled" do
-    expect(@tessen.enabled?).to eq(true)
-    @tessen.options[:enabled] = false
     expect(@tessen.enabled?).to eq(false)
+    @tessen.options[:enabled] = true
+    expect(@tessen.enabled?).to eq(true)
   end
 
   it "can run and stop" do

--- a/spec/server/tessen_spec.rb
+++ b/spec/server/tessen_spec.rb
@@ -89,12 +89,12 @@ describe "Sensu::Server::Tessen" do
       @tessen.redis = setup_redis
       @tessen.create_data do |data|
         expect(data).to be_kind_of(Hash)
-        expect(data[:token]).to be_kind_of(String)
+        expect(data[:tessen_identity_key]).to be_kind_of(String)
         expect(data[:install]).to be_kind_of(Hash)
         expect(data[:install][:id]).to be_kind_of(String)
         expect(data[:install][:id]).to_not be_empty
-        expect(data[:install][:type]).to eq("core")
-        expect(data[:install][:version]).to eq(Sensu::VERSION)
+        expect(data[:install][:sensu_flavour]).to eq("core")
+        expect(data[:install][:sensu_version]).to eq(Sensu::VERSION)
         expect(data[:metrics]).to be_kind_of(Hash)
         expect(data[:metrics][:points]).to be_kind_of(Array)
         expect(data[:metrics][:points].size).to eq(2)

--- a/spec/server/tessen_spec.rb
+++ b/spec/server/tessen_spec.rb
@@ -1,0 +1,141 @@
+require File.join(File.dirname(__FILE__), "..", "helpers.rb")
+
+require "sensu/server/tessen"
+require "sensu/settings"
+require "sensu/logger"
+require "sensu/redis"
+
+describe "Sensu::Server::Tessen" do
+  include Helpers
+
+  before do
+    async_wrapper do
+      @tessen = Sensu::Server::Tessen.new(
+        :settings => Sensu::Settings.get(options),
+        :logger => Sensu::Logger.get(options),
+        :redis => redis
+      )
+      redis.flushdb do
+        redis.sadd("clients", "i-424242") do
+          redis.sadd("servers", "i-424242") do
+            async_done
+          end
+        end
+      end
+    end
+  end
+
+  it "can determine if its enabled" do
+    expect(@tessen.enabled?).to eq(true)
+    @tessen.options[:enabled] = false
+    expect(@tessen.enabled?).to eq(false)
+  end
+
+  it "can run and stop" do
+    async_wrapper do
+      @tessen.run
+      expect(@tessen.timers.size).to eq(1)
+      @tessen.stop
+      expect(@tessen.timers.size).to eq(0)
+      async_done
+    end
+  end
+
+  it "can determine the sensu install id" do
+    async_wrapper do
+      @tessen.redis = setup_redis
+      @tessen.get_install_id do |install_id_one|
+        expect(install_id_one).to be_kind_of(String)
+        expect(install_id_one).to_not be_empty
+        @tessen.get_install_id do |install_id_two|
+          expect(install_id_one).to eq(install_id_two)
+          async_done
+        end
+      end
+    end
+  end
+
+  it "can determine the client count" do
+    async_wrapper do
+      @tessen.redis = setup_redis
+      @tessen.get_client_count do |client_count|
+        expect(client_count).to eq(1)
+        async_done
+      end
+    end
+  end
+
+  it "can determine the server count" do
+    async_wrapper do
+      @tessen.redis = setup_redis
+      @tessen.get_server_count do |server_count|
+        expect(server_count).to eq(1)
+        async_done
+      end
+    end
+  end
+
+  it "can determine the version info" do
+    version_info = @tessen.get_version_info
+    expect(version_info).to be_kind_of(Array)
+    expect(version_info.size).to eq(2)
+    type, version = version_info
+    expect(type).to eq("core")
+    expect(version).to eq(Sensu::VERSION)
+  end
+
+  it "can create data" do
+    async_wrapper do
+      @tessen.redis = setup_redis
+      @tessen.create_data do |data|
+        expect(data).to be_kind_of(Hash)
+        expect(data[:token]).to be_kind_of(String)
+        expect(data[:install]).to be_kind_of(Hash)
+        expect(data[:install][:id]).to be_kind_of(String)
+        expect(data[:install][:id]).to_not be_empty
+        expect(data[:install][:type]).to eq("core")
+        expect(data[:install][:version]).to eq(Sensu::VERSION)
+        expect(data[:metrics]).to be_kind_of(Hash)
+        expect(data[:metrics][:points]).to be_kind_of(Array)
+        expect(data[:metrics][:points].size).to eq(2)
+        async_done
+      end
+    end
+  end
+
+  it "can make a tessen call-home service api request" do
+    tessen_url = "https://tessen.sensu.io/v1/data"
+    stub_request(:post, tessen_url).
+      with(:body => "{\"install\":{\"id\":\"foo\"}}").
+      to_return(:status => 200)
+    async_wrapper do
+      @tessen.tessen_api_request({:install => {:id => "foo"}}) do
+        assert_requested(:post, tessen_url)
+        async_done
+      end
+    end
+  end
+
+  it "can fail to make a tessen call-home service api request" do
+    tessen_url = "https://tessen.sensu.io/v1/data"
+    stub_request(:post, tessen_url).to_return(:status => 500)
+    async_wrapper do
+      @tessen.tessen_api_request({:install => {:id => "foo"}}) do
+        assert_requested(:post, tessen_url)
+        async_done
+      end
+    end
+  end
+
+  it "can send data to the tessen call-home service" do
+    tessen_url = "https://tessen.sensu.io/v1/data"
+    stub_request(:post, tessen_url).to_return(:status => 200)
+    async_wrapper do
+      @tessen.redis = setup_redis
+      @tessen.send_data do
+        assert_requested(:post, tessen_url)
+        async_done
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull-request implements a Sensu call-home mechanism. It sends anonymized data about the Sensu installation to the Tessen hosted service (Sensu Inc), on `sensu-server` startup and every 6 hours thereafter. All data reports are logged for transparency/awareness and transmitted over HTTPS. The anonymized data currently includes the flavour of Sensu (Core or Enterprise), the version, and the Sensu client and server counts.

The data will help the Sensu Team answer questions like:

- How many Sensu installations are there?

- What's the average Sensu client to server ratio?

- What Sensu versions are in use?

- How many installations use Sensu Core vs Enterprise?

![jackyeahs](https://user-images.githubusercontent.com/149630/38648821-1802b34e-3da8-11e8-9de3-ef794cbe8378.gif)

### Enabled by default

The Tessen client is enabled by default, users can **opt-out** via `sensu-server` configuration:

`/etc/sensu/conf.d/tessen.json`

``` json
{
  "tessen": {
    "enabled": false
  }
}
```

### Proxy Configuration

The Tessen client supports proxy configuration.

`/etc/sensu/conf.d/tessen.json`

``` json
{
  "tessen": {
    "proxy": {
      "host": "www.myproxy.com",
      "port": 4430,
      "authorization": ["username", "password"]
    }
  }
}
```

### Future

The Tessen client supports an optional "token" that can be used to sign data (opt-in). This token is not currently supported by the Tessen service, but it could be in the near future. This feature could allow Tessen to "monitor the monitor" or generate reports for Sensu users.