### PR TITLE
Revert "Only posix spawn on x86_64 and i386"

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -8,7 +8,7 @@ gem "sensu-settings", "10.13.1"
 gem "sensu-extension", "1.5.2"
 gem "sensu-extensions", "1.9.1"
 gem "sensu-transport", "7.1.0"
-gem "sensu-spawn", "2.3.0"
+gem "sensu-spawn", "2.2.2"
 gem "sensu-redis", "2.3.0"
 
 require "time"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sensu-extension", "1.5.2"
   s.add_dependency "sensu-extensions", "1.9.1"
   s.add_dependency "sensu-transport", "7.1.0"
-  s.add_dependency "sensu-spawn", "2.3.0"
+  s.add_dependency "sensu-spawn", "2.2.2"
   s.add_dependency "sensu-redis", "2.3.0"
   s.add_dependency "em-http-server", "0.1.8"
   s.add_dependency "parse-cron", "0.1.4"


### PR DESCRIPTION
Reverts sensu/sensu#1843

CentOS 6 segfaulting:
```
/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/childprocess-0.5.8/lib/childprocess/unix/lib.rb:102: [BUG] Segmentation fault at 0x00000000000120
```