### PR TITLE
Use sensu-spawn 2.4.1, it locks FFI to 1.9.21

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -8,7 +8,7 @@ gem "sensu-settings", "10.13.1"
 gem "sensu-extension", "1.5.2"
 gem "sensu-extensions", "1.9.1"
 gem "sensu-transport", "7.1.0"
-gem "sensu-spawn", "2.2.2"
+gem "sensu-spawn", "2.4.1"
 gem "sensu-redis", "2.3.0"
 
 require "time"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sensu-extension", "1.5.2"
   s.add_dependency "sensu-extensions", "1.9.1"
   s.add_dependency "sensu-transport", "7.1.0"
-  s.add_dependency "sensu-spawn", "2.2.2"
+  s.add_dependency "sensu-spawn", "2.4.1"
   s.add_dependency "sensu-redis", "2.3.0"
   s.add_dependency "em-http-server", "0.1.8"
   s.add_dependency "parse-cron", "0.1.4"


### PR DESCRIPTION
This fixes Sensu 1.3.x on CentOS, no more FFI segfaults!

Signed-off-by: Sean Porter <portertech@gmail.com>