### PR TITLE
Use sensu-spawn 2.5.0 to log timeout stop term/kill errors

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -8,7 +8,7 @@ gem "sensu-settings", "10.13.1"
 gem "sensu-extension", "1.5.2"
 gem "sensu-extensions", "1.9.1"
 gem "sensu-transport", "7.1.0"
-gem "sensu-spawn", "2.4.1"
+gem "sensu-spawn", "2.5.0"
 gem "sensu-redis", "2.3.0"
 
 require "time"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sensu-extension", "1.5.2"
   s.add_dependency "sensu-extensions", "1.9.1"
   s.add_dependency "sensu-transport", "7.1.0"
-  s.add_dependency "sensu-spawn", "2.4.1"
+  s.add_dependency "sensu-spawn", "2.5.0"
   s.add_dependency "sensu-redis", "2.3.0"
   s.add_dependency "em-http-server", "0.1.8"
   s.add_dependency "parse-cron", "0.1.4"


### PR DESCRIPTION
Closes https://github.com/sensu/sensu/issues/1831

This pull-request uses sensu-spawn 2.5.0 to log child process timeout stop term/kill errors, like the following:

```
{"timestamp":"2018-04-18T17:28:45.610978-0700","level":"info","message":"publishing check result","payload":{"client":"i-424242","check":{"command":"sudo sleep 10","standalone":true,"interval":10,"timeout":5,"name":"standalone","issued":1524097720,"executed":1524097720,"duration":5.008,"output":"Execution timed out - Unable to TERM/KILL the process: #49814, Operation not permitted","status":2}}}
```