### PR TITLE
Support pagination on all API list endpoints

### DIFF
--- a/lib/sensu/api/routes/aggregates.rb
+++ b/lib/sensu/api/routes/aggregates.rb
@@ -11,6 +11,7 @@ module Sensu
         # GET /aggregates
         def get_aggregates
           @redis.smembers("aggregates") do |aggregates|
+            aggregates = pagination(aggregates)
             aggregates.map! do |aggregate|
               {:name => aggregate}
             end

--- a/lib/sensu/api/routes/checks.rb
+++ b/lib/sensu/api/routes/checks.rb
@@ -7,7 +7,8 @@ module Sensu
 
         # GET /checks
         def get_checks
-          @response_content = @settings.checks.reject { |check| check[:standalone] }
+          checks = @settings.checks.reject { |check| check[:standalone] }
+          @response_content = pagination(checks)
           respond
         end
 

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -304,6 +304,22 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can provide defined checks with pagination" do
+    api_test do
+      http_request(4567, "/checks?limit=1") do |http, body|
+        expect(http.response_header.status).to eq(200)
+        expect(body).to be_kind_of(Array)
+        expect(body.length).to eq(1)
+        http_request(4567, "/checks?limit=1&offset=1") do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Array)
+          expect(body.length).to eq(1)
+          async_done
+        end
+      end
+    end
+  end
+
   it "can provide defined checks without standalone checks" do
     api_test do
       http_request(4567, "/checks") do |http, body|

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -1423,6 +1423,22 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can provide current results with pagination" do
+    api_test do
+      http_request(4567, "/results?limit=1") do |http, body|
+        expect(http.response_header.status).to eq(200)
+        expect(body).to be_kind_of(Array)
+        expect(body.length).to eq(1)
+        http_request(4567, "/results?limit=1&offset=1") do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Array)
+          expect(body).to be_empty
+          async_done
+        end
+      end
+    end
+  end
+
   it "can provide current results for a specific client" do
     api_test do
       http_request(4567, "/results/i-424242") do |http, body|
@@ -1434,6 +1450,22 @@ describe "Sensu::API::Process" do
         end
         expect(body).to contain(test_result)
         async_done
+      end
+    end
+  end
+
+  it "can provide current results for a specific client with pagination" do
+    api_test do
+      http_request(4567, "/results/i-424242?limit=1") do |http, body|
+        expect(http.response_header.status).to eq(200)
+        expect(body).to be_kind_of(Array)
+        expect(body.length).to eq(1)
+        http_request(4567, "/results/i-424242?limit=1&offset=1") do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Array)
+          expect(body).to be_empty
+          async_done
+        end
       end
     end
   end

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -1053,6 +1053,26 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can provide a list of aggregates with pagination" do
+    api_test do
+      server = Sensu::Server::Process.new(options)
+      server.setup_redis do
+        server.aggregate_check_result(client_template, check_template)
+        timer(1) do
+          http_request(4567, "/aggregates?limit=1") do |http, body|
+            expect(body).to be_kind_of(Array)
+            expect(body.length).to eq(1)
+            http_request(4567, "/aggregates?limit=1&offset=1") do |http, body|
+              expect(body).to be_kind_of(Array)
+              expect(body).to be_empty
+              async_done
+            end
+          end
+        end
+      end
+    end
+  end
+
   it "can delete an aggregate" do
     api_test do
       server = Sensu::Server::Process.new(options)

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -128,6 +128,22 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can provide current events with pagination" do
+    api_test do
+      http_request(4567, "/events?limit=1") do |http, body|
+        expect(http.response_header.status).to eq(200)
+        expect(body).to be_kind_of(Array)
+        expect(body.length).to eq(1)
+        http_request(4567, "/events?limit=1&offset=1") do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Array)
+          expect(body).to be_empty
+          async_done
+        end
+      end
+    end
+  end
+
   it "can provide current events for a specific client" do
     api_test do
       http_request(4567, "/events/i-424242") do |http, body|
@@ -138,6 +154,22 @@ describe "Sensu::API::Process" do
         end
         expect(body).to contain(test_event)
         async_done
+      end
+    end
+  end
+
+  it "can provide current events for a specific client with pagination" do
+    api_test do
+      http_request(4567, "/events/i-424242?limit=1") do |http, body|
+        expect(http.response_header.status).to eq(200)
+        expect(body).to be_kind_of(Array)
+        expect(body.length).to eq(1)
+        http_request(4567, "/events/i-424242?limit=1&offset=1") do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Array)
+          expect(body).to be_empty
+          async_done
+        end
       end
     end
   end


### PR DESCRIPTION
Closes https://github.com/sensu/sensu/issues/1830

This pull-request adds pagination support to all API list endpoints, e.g. `/events` and `/results`.

The pagination helper put to use is at: https://github.com/sensu/sensu/blob/2d8d536212de154b6c68a49e4717528c8321ab58/lib/sensu/api/http_handler.rb#L163-L188