### PR TITLE
1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ## [Unreleased]
 - Sensu call-home mechanism, the Tessen client (opt-in). It sends anonymized data about the Sensu installation to the Tessen hosted service (Sensu Inc), on sensu-server startup and every 6 hours thereafter. All data reports are logged for transparency/awareness and transmitted over HTTPS. The anonymized data currently includes the flavour of Sensu (Core or Enterprise), the Sensu version, and the Sensu client and server counts.
 - Support for writing multiple check results to the client socket (in one payload).
-- API list endpoints (e.g. /events) now all support pagination
+- API list endpoints (e.g. /events) now all support pagination.
+- Improved event last_ok, now updating the value when storing latest check results for better accuracy.
 
 ## [1.3.3] - 2018-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ## [Unreleased]
 - Sensu call-home mechanism, the Tessen client (opt-in). It sends anonymized data about the Sensu installation to the Tessen hosted service (Sensu Inc), on sensu-server startup and every 6 hours thereafter. All data reports are logged for transparency/awareness and transmitted over HTTPS. The anonymized data currently includes the flavour of Sensu (Core or Enterprise), the Sensu version, and the Sensu client and server counts.
 - Support for writing multiple check results to the client socket (in one payload).
+- API list endpoints (e.g. /events) now all support pagination
 
 ## [1.3.3] - 2018-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- Sensu call-home mechanism, the Tessen client (opt-in). It sends anonymized data about the Sensu installation to the Tessen hosted service (Sensu Inc), on sensu-server startup and every 6 hours thereafter. All data reports are logged for transparency/awareness and transmitted over HTTPS. The anonymized data currently includes the flavour of Sensu (Core or Enterprise), the Sensu version, and the Sensu client and server counts.
+- Support for writing multiple check results to the client socket (in one payload).
 
 ## [1.3.3] - 2018-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+
+## [1.4.0] - 2018-05-02
+
+### Added
 - Sensu call-home mechanism, the Tessen client (opt-in). It sends anonymized data about the Sensu installation to the Tessen hosted service (Sensu Inc), on sensu-server startup and every 6 hours thereafter. All data reports are logged for transparency/awareness and transmitted over HTTPS. The anonymized data currently includes the flavour of Sensu (Core or Enterprise), the Sensu version, and the Sensu client and server counts.
+
+### Changed
 - Support for writing multiple check results to the client socket (in one payload).
 - API list endpoints (e.g. /events) now all support pagination.
 - Improved event last_ok, now updating the value when storing latest check results for better accuracy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ### Added
 - Sensu call-home mechanism, the Tessen client (opt-in). It sends anonymized data about the Sensu installation to the Tessen hosted service (Sensu Inc), on sensu-server startup and every 6 hours thereafter. All data reports are logged for transparency/awareness and transmitted over HTTPS. The anonymized data currently includes the flavour of Sensu (Core or Enterprise), the Sensu version, and the Sensu client and server counts.
+- API list endpoints (e.g. /events) now all support pagination.
 
 ### Changed
 - Support for writing multiple check results to the client socket (in one payload).
-- API list endpoints (e.g. /events) now all support pagination.
 - Improved event last_ok, now updating the value when storing latest check results for better accuracy.
+
+### Fixed
+- Include child process (e.g. check execution) stop (SIGTERM/KILL) error message in timeout output. This helps when debugging defunct/zombie processes, e.g. "Execution timed out - Unable to TERM/KILL the process: Operation not permitted".
 
 ## [1.3.3] - 2018-04-18
 

--- a/lib/sensu/api/routes/aggregates.rb
+++ b/lib/sensu/api/routes/aggregates.rb
@@ -11,6 +11,7 @@ module Sensu
         # GET /aggregates
         def get_aggregates
           @redis.smembers("aggregates") do |aggregates|
+            aggregates = pagination(aggregates)
             aggregates.map! do |aggregate|
               {:name => aggregate}
             end

--- a/lib/sensu/api/routes/checks.rb
+++ b/lib/sensu/api/routes/checks.rb
@@ -7,7 +7,8 @@ module Sensu
 
         # GET /checks
         def get_checks
-          @response_content = @settings.checks.reject { |check| check[:standalone] }
+          checks = @settings.checks.reject { |check| check[:standalone] }
+          @response_content = pagination(checks)
           respond
         end
 

--- a/lib/sensu/api/routes/results.rb
+++ b/lib/sensu/api/routes/results.rb
@@ -132,8 +132,11 @@ module Sensu
             if result_exists
               @redis.srem("result:#{client_name}", check_name) do
                 @redis.del(result_key) do
-                  @redis.del("history:#{client_name}:#{check_name}") do
-                    no_content!
+                  history_key = "history:#{client_name}:#{check_name}"
+                  @redis.del(history_key) do
+                    @redis.del("#{history_key}:last_ok") do
+                      no_content!
+                    end
                   end
                 end
               end

--- a/lib/sensu/api/routes/results.rb
+++ b/lib/sensu/api/routes/results.rb
@@ -30,30 +30,35 @@ module Sensu
           @response_content = []
           @redis.smembers("clients") do |clients|
             unless clients.empty?
+              result_keys = []
               clients.each_with_index do |client_name, client_index|
                 @redis.smembers("result:#{client_name}") do |checks|
-                  if !checks.empty?
-                    checks.each_with_index do |check_name, check_index|
-                      result_key = "result:#{client_name}:#{check_name}"
-                      @redis.get(result_key) do |result_json|
-                        history_key = "history:#{client_name}:#{check_name}"
-                        @redis.lrange(history_key, -21, -1) do |history|
-                          history.map! do |status|
-                            status.to_i
-                          end
-                          unless result_json.nil?
-                            check = Sensu::JSON.load(result_json)
-                            check[:history] = history
-                            @response_content << {:client => client_name, :check => check}
-                          end
-                          if client_index == clients.length - 1 && check_index == checks.length - 1
-                            respond
+                  checks.each do |check_name|
+                    result_keys << "result:#{client_name}:#{check_name}"
+                  end
+                  if client_index == clients.length - 1
+                    result_keys = pagination(result_keys)
+                    unless result_keys.empty?
+                      result_keys.each_with_index do |result_key, result_key_index|
+                        @redis.get(result_key) do |result_json|
+                          _, client_name, check_name = result_key.split(":")
+                          history_key = "history:#{client_name}:#{check_name}"
+                          @redis.lrange(history_key, -21, -1) do |history|
+                            history.map! do |status|
+                              status.to_i
+                            end
+                            unless result_json.nil?
+                              check = Sensu::JSON.load(result_json)
+                              check[:history] = history
+                              @response_content << {:client => client_name, :check => check}
+                            end
+                            if result_key_index == result_keys.length - 1
+                              respond
+                            end
                           end
                         end
                       end
-                    end
-                  elsif client_index == clients.length - 1
-                    @redis.ping do
+                    else
                       respond
                     end
                   end
@@ -70,6 +75,7 @@ module Sensu
           client_name = parse_uri(RESULTS_CLIENT_URI).first
           @response_content = []
           @redis.smembers("result:#{client_name}") do |checks|
+            checks = pagination(checks)
             unless checks.empty?
               checks.each_with_index do |check_name, check_index|
                 result_key = "result:#{client_name}:#{check_name}"

--- a/lib/sensu/client/http_socket.rb
+++ b/lib/sensu/client/http_socket.rb
@@ -129,8 +129,14 @@ module Sensu
         end
         if @http[:content_type] and @http[:content_type].include?("application/json") and @http_content
           begin
-            check = Sensu::JSON::load(@http_content)
-            process_check_result(check)
+            object = Sensu::JSON::load(@http_content)
+            if object.instance_of? Array
+              for check in object do
+                process_check_result(check)
+              end
+            else
+              process_check_result(object)
+            end
             send_response(202, "OK", {:response => "ok"})
           rescue Sensu::JSON::ParseError, ArgumentError
             send_response(400, "Failed to parse JSON body", {:response => "Failed to parse JSON body"})

--- a/lib/sensu/client/http_socket.rb
+++ b/lib/sensu/client/http_socket.rb
@@ -130,8 +130,8 @@ module Sensu
         if @http[:content_type] and @http[:content_type].include?("application/json") and @http_content
           begin
             object = Sensu::JSON::load(@http_content)
-            if object.instance_of? Array
-              for check in object do
+            if object.is_a?(Array)
+              object.each do |check|
                 process_check_result(check)
               end
             else

--- a/lib/sensu/client/socket.rb
+++ b/lib/sensu/client/socket.rb
@@ -123,9 +123,15 @@ module Sensu
       # @param [String] data to parse for a check result.
       def parse_check_result(data)
         begin
-          check = Sensu::JSON.load(data)
+          object = Sensu::JSON.load(data)
           cancel_watchdog
-          process_check_result(check)
+          if object.instance_of? Array
+            for check in object do
+              process_check_result(check)
+            end
+          else
+            process_check_result(object)
+          end
           respond("ok")
         rescue Sensu::JSON::ParseError, ArgumentError => error
           if @protocol == :tcp

--- a/lib/sensu/client/socket.rb
+++ b/lib/sensu/client/socket.rb
@@ -116,17 +116,17 @@ module Sensu
         end
       end
 
-      # Parse a JSON check result. For UDP, immediately raise a parser
-      # error. For TCP, record parser errors, so the connection
-      # +watchdog+ can report them.
+      # Parse one or more JSON check results. For UDP, immediately
+      # raise a parser error. For TCP, record parser errors, so the
+      # connection +watchdog+ can report them.
       #
       # @param [String] data to parse for a check result.
       def parse_check_result(data)
         begin
           object = Sensu::JSON.load(data)
           cancel_watchdog
-          if object.instance_of? Array
-            for check in object do
+          if object.is_a?(Array)
+            object.each do |check|
               process_check_result(check)
             end
           else

--- a/lib/sensu/constants.rb
+++ b/lib/sensu/constants.rb
@@ -1,7 +1,7 @@
 module Sensu
   unless defined?(Sensu::VERSION)
     # Sensu release version.
-    VERSION = "1.3.3".freeze
+    VERSION = "1.4.0".freeze
 
     # Sensu release information.
     RELEASE_INFO = {

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -8,7 +8,7 @@ gem "sensu-settings", "10.13.1"
 gem "sensu-extension", "1.5.2"
 gem "sensu-extensions", "1.9.1"
 gem "sensu-transport", "7.1.0"
-gem "sensu-spawn", "2.4.1"
+gem "sensu-spawn", "2.5.0"
 gem "sensu-redis", "2.3.0"
 
 require "time"

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.5"
 
 gem "sensu-json", "2.1.1"
 gem "sensu-logger", "1.2.2"
-gem "sensu-settings", "10.13.1"
+gem "sensu-settings", "10.14.0"
 gem "sensu-extension", "1.5.2"
 gem "sensu-extensions", "1.9.1"
 gem "sensu-transport", "7.1.0"

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -1432,7 +1432,7 @@ module Sensu
             }
           )
           tessen = @settings[:tessen] || {}
-          tessen_enabled = tessen.fetch(:enabled, true)
+          tessen_enabled = tessen.fetch(:enabled, false)
           info = {
             :id => server_id,
             :hostname => system_hostname,

--- a/lib/sensu/server/tessen.rb
+++ b/lib/sensu/server/tessen.rb
@@ -70,15 +70,15 @@ module Sensu
         get_install_id do |install_id|
           get_client_count do |client_count|
             get_server_count do |server_count|
-              token = @options.fetch(:token, "")
-              type, version = get_version_info
+              identity_key = @options.fetch(:identity_key, "")
+              flavour, version = get_version_info
               timestamp = Time.now.to_i
               data = {
-                :token => token,
+                :tessen_identity_key => identity_key,
                 :install => {
                   :id => install_id,
-                  :type => type,
-                  :version => version
+                  :sensu_flavour => flavour,
+                  :sensu_version => version
                 },
                 :metrics => {
                   :points => [

--- a/lib/sensu/server/tessen.rb
+++ b/lib/sensu/server/tessen.rb
@@ -1,0 +1,165 @@
+require "em-http-request"
+require "sensu/constants"
+
+module Sensu
+  module Server
+    class Tessen
+      attr_accessor :settings, :logger, :redis, :options
+      attr_reader :timers
+
+      # Create a new instance of Tessen. The instance variable
+      # `@timers` is use to track EventMachine timers for
+      # stopping/shutdown.
+      #
+      # @param options [Hash] containing the Sensu server Settings,
+      #   Logger, and Redis connection.
+      def initialize(options={})
+        @timers = []
+        @settings = options[:settings]
+        @logger = options[:logger]
+        @redis = options[:redis]
+        @options = @settings.to_hash.fetch(:tessen, {})
+      end
+
+      # Determine if Tessen is enabled (opt-out).
+      #
+      # @return [TrueClass, FalseClass]
+      def enabled?
+        @options[:enabled] != false
+      end
+
+      # Run Tessen, scheduling data reports (every 6h).
+      def run
+        schedule_data_reports
+      end
+
+      # Stop Tessen, cancelling and clearing timers.
+      def stop
+        @timers.each do |timer|
+          timer.cancel
+        end
+        @timers.clear
+      end
+
+      # Schedule data reports, sending data to the Tessen service
+      # immediately and then every 6 hours after that.
+      def schedule_data_reports
+        note = "this data helps inform the sensu team about installations"
+        note << " - you can choose to opt-out via configuration: {\"tessen\": {\"enabled\": false}}"
+        @logger.info("sending anonymized data to the tessen call-home service", :note => note)
+        send_data
+        @timers << EM::PeriodicTimer.new(21600) do
+          send_data
+        end
+      end
+
+      # Send data to the Tessen service.
+      def send_data(&block)
+        create_data do |data|
+          tessen_api_request(data, &block)
+        end
+      end
+
+      # Create data to be sent to the Tessen service.
+      #
+      # @return [Hash]
+      def create_data
+        get_install_id do |install_id|
+          get_client_count do |client_count|
+            get_server_count do |server_count|
+              token = @options.fetch(:token, "")
+              type, version = get_version_info
+              timestamp = Time.now.to_i
+              data = {
+                :token => token,
+                :install => {
+                  :id => install_id,
+                  :type => type,
+                  :version => version
+                },
+                :metrics => {
+                  :points => [
+                    {
+                      :name => "client_count",
+                      :value => client_count,
+                      :timestamp => timestamp
+                    },
+                    {
+                      :name => "server_count",
+                      :value => server_count,
+                      :timestamp => timestamp
+                    }
+                  ]
+                }
+              }
+              yield data
+            end
+          end
+        end
+      end
+
+      # Get the Sensu installation ID. The ID is randomly generated
+      # and stored in Redis. This ID provides context and allows
+      # multiple Sensu servers to report data for the same installation.
+      def get_install_id
+        @redis.setnx("tessen:install_id", rand(36**12).to_s(36)) do |created|
+          @redis.get("tessen:install_id") do |install_id|
+            yield install_id
+          end
+        end
+      end
+
+      # Get the Sensu client count for the installation. This count
+      # currently includes proxy clients.
+      #
+      # @yield [count]
+      # @yieldparam [Integer] client count
+      def get_client_count
+        @redis.scard("clients") do |count|
+          yield count.to_i
+        end
+      end
+
+      # Get the Sensu server count for the installation.
+      #
+      # @yield [count]
+      # @yieldparam [Integer] server count
+      def get_server_count
+        @redis.scard("servers") do |count|
+          yield count.to_i
+        end
+      end
+
+      # Get the Sensu version info for the local Sensu service.
+      def get_version_info
+        if defined?(Sensu::Enterprise::VERSION)
+          ["enterprise", Sensu::Enterprise::VERSION]
+        else
+          ["core", Sensu::VERSION]
+        end
+      end
+
+      # Make a Tessen service API request.
+      #
+      # @param data [Hash]
+      def tessen_api_request(data)
+        @logger.debug("sending data to the tessen call-home service", {
+          :data => data,
+          :options => @options
+        })
+        connection = {}
+        connection[:proxy] = @options[:proxy] if @options[:proxy]
+        post_options = {:body => Sensu::JSON.dump(data)}
+        http = EM::HttpRequest.new("https://tessen.sensu.io/v1/data", connection).post(post_options)
+        http.callback do
+          @logger.debug("tessen call-home service response", :status => http.response_header.status)
+          yield if block_given?
+        end
+        http.errback do
+          @logger.debug("tessen call-home service error", :error => http.error)
+          yield if block_given?
+        end
+      end
+    end
+  end
+end

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.5"
   s.add_dependency "sensu-json", "2.1.1"
   s.add_dependency "sensu-logger", "1.2.2"
-  s.add_dependency "sensu-settings", "10.13.1"
+  s.add_dependency "sensu-settings", "10.14.0"
   s.add_dependency "sensu-extension", "1.5.2"
   s.add_dependency "sensu-extensions", "1.9.1"
   s.add_dependency "sensu-transport", "7.1.0"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sensu-extension", "1.5.2"
   s.add_dependency "sensu-extensions", "1.9.1"
   s.add_dependency "sensu-transport", "7.1.0"
-  s.add_dependency "sensu-spawn", "2.4.1"
+  s.add_dependency "sensu-spawn", "2.5.0"
   s.add_dependency "sensu-redis", "2.3.0"
   s.add_dependency "em-http-server", "0.1.8"
   s.add_dependency "parse-cron", "0.1.4"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "em-http-request", "~> 1.1"
   s.add_development_dependency "addressable", "2.3.8"
+  s.add_development_dependency "webmock", "3.3.0"
 
   s.files         = Dir.glob("{exe,lib}/**/*") + %w[sensu.gemspec README.md CHANGELOG.md MIT-LICENSE.txt]
   s.executables   = s.files.grep(%r{^exe/}) { |file| File.basename(file) }

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -128,6 +128,22 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can provide current events with pagination" do
+    api_test do
+      http_request(4567, "/events?limit=1") do |http, body|
+        expect(http.response_header.status).to eq(200)
+        expect(body).to be_kind_of(Array)
+        expect(body.length).to eq(1)
+        http_request(4567, "/events?limit=1&offset=1") do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Array)
+          expect(body).to be_empty
+          async_done
+        end
+      end
+    end
+  end
+
   it "can provide current events for a specific client" do
     api_test do
       http_request(4567, "/events/i-424242") do |http, body|
@@ -138,6 +154,22 @@ describe "Sensu::API::Process" do
         end
         expect(body).to contain(test_event)
         async_done
+      end
+    end
+  end
+
+  it "can provide current events for a specific client with pagination" do
+    api_test do
+      http_request(4567, "/events/i-424242?limit=1") do |http, body|
+        expect(http.response_header.status).to eq(200)
+        expect(body).to be_kind_of(Array)
+        expect(body.length).to eq(1)
+        http_request(4567, "/events/i-424242?limit=1&offset=1") do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Array)
+          expect(body).to be_empty
+          async_done
+        end
       end
     end
   end
@@ -300,6 +332,22 @@ describe "Sensu::API::Process" do
         end
         expect(body).to contain(test_check)
         async_done
+      end
+    end
+  end
+
+  it "can provide defined checks with pagination" do
+    api_test do
+      http_request(4567, "/checks?limit=1") do |http, body|
+        expect(http.response_header.status).to eq(200)
+        expect(body).to be_kind_of(Array)
+        expect(body.length).to eq(1)
+        http_request(4567, "/checks?limit=1&offset=1") do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Array)
+          expect(body.length).to eq(1)
+          async_done
+        end
       end
     end
   end
@@ -1053,6 +1101,26 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can provide a list of aggregates with pagination" do
+    api_test do
+      server = Sensu::Server::Process.new(options)
+      server.setup_redis do
+        server.aggregate_check_result(client_template, check_template)
+        timer(1) do
+          http_request(4567, "/aggregates?limit=1") do |http, body|
+            expect(body).to be_kind_of(Array)
+            expect(body.length).to eq(1)
+            http_request(4567, "/aggregates?limit=1&offset=1") do |http, body|
+              expect(body).to be_kind_of(Array)
+              expect(body).to be_empty
+              async_done
+            end
+          end
+        end
+      end
+    end
+  end
+
   it "can delete an aggregate" do
     api_test do
       server = Sensu::Server::Process.new(options)
@@ -1423,6 +1491,22 @@ describe "Sensu::API::Process" do
     end
   end
 
+  it "can provide current results with pagination" do
+    api_test do
+      http_request(4567, "/results?limit=1") do |http, body|
+        expect(http.response_header.status).to eq(200)
+        expect(body).to be_kind_of(Array)
+        expect(body.length).to eq(1)
+        http_request(4567, "/results?limit=1&offset=1") do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Array)
+          expect(body).to be_empty
+          async_done
+        end
+      end
+    end
+  end
+
   it "can provide current results for a specific client" do
     api_test do
       http_request(4567, "/results/i-424242") do |http, body|
@@ -1434,6 +1518,22 @@ describe "Sensu::API::Process" do
         end
         expect(body).to contain(test_result)
         async_done
+      end
+    end
+  end
+
+  it "can provide current results for a specific client with pagination" do
+    api_test do
+      http_request(4567, "/results/i-424242?limit=1") do |http, body|
+        expect(http.response_header.status).to eq(200)
+        expect(body).to be_kind_of(Array)
+        expect(body.length).to eq(1)
+        http_request(4567, "/results/i-424242?limit=1&offset=1") do |http, body|
+          expect(http.response_header.status).to eq(200)
+          expect(body).to be_kind_of(Array)
+          expect(body).to be_empty
+          async_done
+        end
       end
     end
   end

--- a/spec/client/http_socket_spec.rb
+++ b/spec/client/http_socket_spec.rb
@@ -50,6 +50,30 @@ describe "Sensu::Client::HTTPSocket" do
     end
   end
 
+  it "can accept multiple external check results input" do
+    async_wrapper do
+      @client.setup_transport do
+        @client.setup_http_socket
+        result_queue do |payload|
+          result = Sensu::JSON.load(payload)
+          expect(result[:client]).to eq("i-424242")
+          expect(result[:check][:name]).to eq("http")
+          async_done
+        end
+        timer(1) do
+          options = {:body => [{:name => "http", :output => "http", :status => 1},
+                               {:name => "http", :output => "http2", :status => 0},
+                               {:name => "http", :output => "http3", :status => 2}]}
+          http_request(3031, "/results", :post, options)do |http, body|
+            len = options[:body].length-1
+            expect(http.response_header.status).to eq(202)
+            expect(body).to eq({:response => "ok"})
+          end
+        end
+      end
+    end
+  end
+
   it "can provide settings" do
     async_wrapper do
       @client.setup_transport do

--- a/spec/client/socket_spec.rb
+++ b/spec/client/socket_spec.rb
@@ -154,6 +154,21 @@ describe Sensu::Client::Socket do
       expect(subject).to receive(:respond).with("ok")
       subject.parse_check_result(json_check_data)
     end
+    
+    it "also accepts multiple check results" do
+      json_check_data = "[{\"name\": \"test1\", \"output\": \"good!\"},
+                          {\"name\": \"test2\", \"output\": \"still good!\"}]"
+      checks = [{:name => "test1", :output => "good!"},
+                {:name => "test2", :output => "still good!"}]
+      expect(subject).to receive(:cancel_watchdog)
+      len = checks.length-1
+      for i in (0..len) do
+        expect(subject).to receive(:process_check_result).with(checks[i])
+      end
+      expect(subject).to receive(:respond).with("ok")
+      subject.parse_check_result(json_check_data)
+    end
+    
   end
 
   describe "#process_data" do

--- a/spec/config.json
+++ b/spec/config.json
@@ -222,7 +222,10 @@
     "keepalive": {
       "thresholds": {
         "warning": 10
-      }
+      },
+      "contacts": [
+        ":::primary_contact|ops:::"
+      ]
     },
     "deregister": true,
     "deregistration": {

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -3,6 +3,9 @@ require "eventmachine"
 require "em-http-request"
 require "securerandom"
 require "sensu/json"
+require "webmock/rspec"
+
+WebMock.allow_net_connect!
 
 module Helpers
   def setup_options

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -1081,6 +1081,7 @@ describe "Sensu::Server::Process" do
                 expect(server[:tasks]).to be_kind_of(Array)
                 expect(server[:sensu][:version]).to eq(Sensu::VERSION)
                 expect(server[:sensu][:settings][:hexdigest]).to be_kind_of(String)
+                expect(server[:tessen][:enabled]).to eq(true)
                 expect(server[:timestamp]).to be_within(5).of(Time.now.to_i)
                 async_done
               end

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -216,6 +216,7 @@ describe "Sensu::Server::Process" do
               result[:check][:low_flap_threshold] = 5
               result[:check][:high_flap_threshold] = 20
               result[:check][:status] = index % 2
+              result[:check][:executed] = epoch
               @server.process_check_result(result)
             end
             timer(1) do
@@ -225,6 +226,7 @@ describe "Sensu::Server::Process" do
                   event = Sensu::JSON.load(event_json)
                   expect(event[:action]).to eq("flapping")
                   expect(event[:occurrences]).to be_within(2).of(1)
+                  expect(event[:last_ok]).to be_within(10).of(epoch)
                   26.times do |index|
                     result = result_template
                     result[:check][:low_flap_threshold] = 5
@@ -263,6 +265,7 @@ describe "Sensu::Server::Process" do
               result[:check][:low_flap_threshold] = 5
               result[:check][:high_flap_threshold] = 20
               result[:check][:status] = index % 2
+              result[:check][:executed] = epoch
               @server.process_check_result(result)
             end
             timer(1) do
@@ -270,6 +273,7 @@ describe "Sensu::Server::Process" do
                 event = Sensu::JSON.load(event_json)
                 expect(event[:action]).to eq("flapping")
                 expect(event[:occurrences]).to be_within(2).of(1)
+                expect(event[:last_ok]).to be_within(10).of(epoch)
                 result = result_template
                 result[:check][:low_flap_threshold] = 5
                 result[:check][:high_flap_threshold] = 20
@@ -475,7 +479,7 @@ describe "Sensu::Server::Process" do
                             expect(event[:check][:status]).to eq(1)
                             expect(event[:occurrences]).to eq(2)
                             expect(event[:occurrences_watermark]).to eq(2)
-                            expect(event[:last_ok]).to be_within(30).of(epoch)
+                            expect(event[:last_ok]).to be_nil
                             expect(event[:silenced]).to eq(false)
                             expect(event[:silenced_by]).to be_empty
                             expect(event[:action]).to eq("create")

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -1081,7 +1081,7 @@ describe "Sensu::Server::Process" do
                 expect(server[:tasks]).to be_kind_of(Array)
                 expect(server[:sensu][:version]).to eq(Sensu::VERSION)
                 expect(server[:sensu][:settings][:hexdigest]).to be_kind_of(String)
-                expect(server[:tessen][:enabled]).to eq(true)
+                expect(server[:tessen][:enabled]).to eq(false)
                 expect(server[:timestamp]).to be_within(5).of(Time.now.to_i)
                 async_done
               end

--- a/spec/server/tessen_spec.rb
+++ b/spec/server/tessen_spec.rb
@@ -26,9 +26,9 @@ describe "Sensu::Server::Tessen" do
   end
 
   it "can determine if its enabled" do
-    expect(@tessen.enabled?).to eq(true)
-    @tessen.options[:enabled] = false
     expect(@tessen.enabled?).to eq(false)
+    @tessen.options[:enabled] = true
+    expect(@tessen.enabled?).to eq(true)
   end
 
   it "can run and stop" do

--- a/spec/server/tessen_spec.rb
+++ b/spec/server/tessen_spec.rb
@@ -89,12 +89,12 @@ describe "Sensu::Server::Tessen" do
       @tessen.redis = setup_redis
       @tessen.create_data do |data|
         expect(data).to be_kind_of(Hash)
-        expect(data[:token]).to be_kind_of(String)
+        expect(data[:tessen_identity_key]).to be_kind_of(String)
         expect(data[:install]).to be_kind_of(Hash)
         expect(data[:install][:id]).to be_kind_of(String)
         expect(data[:install][:id]).to_not be_empty
-        expect(data[:install][:type]).to eq("core")
-        expect(data[:install][:version]).to eq(Sensu::VERSION)
+        expect(data[:install][:sensu_flavour]).to eq("core")
+        expect(data[:install][:sensu_version]).to eq(Sensu::VERSION)
         expect(data[:metrics]).to be_kind_of(Hash)
         expect(data[:metrics][:points]).to be_kind_of(Array)
         expect(data[:metrics][:points].size).to eq(2)

--- a/spec/server/tessen_spec.rb
+++ b/spec/server/tessen_spec.rb
@@ -1,0 +1,141 @@
+require File.join(File.dirname(__FILE__), "..", "helpers.rb")
+
+require "sensu/server/tessen"
+require "sensu/settings"
+require "sensu/logger"
+require "sensu/redis"
+
+describe "Sensu::Server::Tessen" do
+  include Helpers
+
+  before do
+    async_wrapper do
+      @tessen = Sensu::Server::Tessen.new(
+        :settings => Sensu::Settings.get(options),
+        :logger => Sensu::Logger.get(options),
+        :redis => redis
+      )
+      redis.flushdb do
+        redis.sadd("clients", "i-424242") do
+          redis.sadd("servers", "i-424242") do
+            async_done
+          end
+        end
+      end
+    end
+  end
+
+  it "can determine if its enabled" do
+    expect(@tessen.enabled?).to eq(true)
+    @tessen.options[:enabled] = false
+    expect(@tessen.enabled?).to eq(false)
+  end
+
+  it "can run and stop" do
+    async_wrapper do
+      @tessen.run
+      expect(@tessen.timers.size).to eq(1)
+      @tessen.stop
+      expect(@tessen.timers.size).to eq(0)
+      async_done
+    end
+  end
+
+  it "can determine the sensu install id" do
+    async_wrapper do
+      @tessen.redis = setup_redis
+      @tessen.get_install_id do |install_id_one|
+        expect(install_id_one).to be_kind_of(String)
+        expect(install_id_one).to_not be_empty
+        @tessen.get_install_id do |install_id_two|
+          expect(install_id_one).to eq(install_id_two)
+          async_done
+        end
+      end
+    end
+  end
+
+  it "can determine the client count" do
+    async_wrapper do
+      @tessen.redis = setup_redis
+      @tessen.get_client_count do |client_count|
+        expect(client_count).to eq(1)
+        async_done
+      end
+    end
+  end
+
+  it "can determine the server count" do
+    async_wrapper do
+      @tessen.redis = setup_redis
+      @tessen.get_server_count do |server_count|
+        expect(server_count).to eq(1)
+        async_done
+      end
+    end
+  end
+
+  it "can determine the version info" do
+    version_info = @tessen.get_version_info
+    expect(version_info).to be_kind_of(Array)
+    expect(version_info.size).to eq(2)
+    type, version = version_info
+    expect(type).to eq("core")
+    expect(version).to eq(Sensu::VERSION)
+  end
+
+  it "can create data" do
+    async_wrapper do
+      @tessen.redis = setup_redis
+      @tessen.create_data do |data|
+        expect(data).to be_kind_of(Hash)
+        expect(data[:token]).to be_kind_of(String)
+        expect(data[:install]).to be_kind_of(Hash)
+        expect(data[:install][:id]).to be_kind_of(String)
+        expect(data[:install][:id]).to_not be_empty
+        expect(data[:install][:type]).to eq("core")
+        expect(data[:install][:version]).to eq(Sensu::VERSION)
+        expect(data[:metrics]).to be_kind_of(Hash)
+        expect(data[:metrics][:points]).to be_kind_of(Array)
+        expect(data[:metrics][:points].size).to eq(2)
+        async_done
+      end
+    end
+  end
+
+  it "can make a tessen call-home service api request" do
+    tessen_url = "https://tessen.sensu.io/v1/data"
+    stub_request(:post, tessen_url).
+      with(:body => "{\"install\":{\"id\":\"foo\"}}").
+      to_return(:status => 200)
+    async_wrapper do
+      @tessen.tessen_api_request({:install => {:id => "foo"}}) do
+        assert_requested(:post, tessen_url)
+        async_done
+      end
+    end
+  end
+
+  it "can fail to make a tessen call-home service api request" do
+    tessen_url = "https://tessen.sensu.io/v1/data"
+    stub_request(:post, tessen_url).to_return(:status => 500)
+    async_wrapper do
+      @tessen.tessen_api_request({:install => {:id => "foo"}}) do
+        assert_requested(:post, tessen_url)
+        async_done
+      end
+    end
+  end
+
+  it "can send data to the tessen call-home service" do
+    tessen_url = "https://tessen.sensu.io/v1/data"
+    stub_request(:post, tessen_url).to_return(:status => 200)
+    async_wrapper do
+      @tessen.redis = setup_redis
+      @tessen.send_data do
+        assert_requested(:post, tessen_url)
+        async_done
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull-request is for the 1.4.0 release.

## [1.4.0] - 2018-05-02

### Added
- Sensu call-home mechanism, the Tessen client (opt-in). It sends anonymized data about the Sensu installation to the Tessen hosted service (Sensu Inc), on sensu-server startup and every 6 hours thereafter. All data reports are logged for transparency/awareness and transmitted over HTTPS. The anonymized data currently includes the flavour of Sensu (Core or Enterprise), the Sensu version, and the Sensu client and server counts.

### Changed
- Support for writing multiple check results to the client socket (in one payload).
- API list endpoints (e.g. /events) now all support pagination.
- Improved event last_ok, now updating the value when storing latest check results for better accuracy.

### Fixed
- Include child process (e.g. check execution) stop (SIGTERM/KILL) error message in timeout output. This helps when debugging defunct/zombie processes, e.g. "Execution timed out - Unable to TERM/KILL the process: Operation not permitted".