### PR TITLE
Fixed API GET /results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Fixed
+- Fixed API GET /results, results were incorrectly reported under a single client name.
+
 ## [1.4.1] - 2018-05-04
 
 ### Fixed

--- a/lib/sensu/api/routes/results.rb
+++ b/lib/sensu/api/routes/results.rb
@@ -41,13 +41,13 @@ module Sensu
                     unless result_keys.empty?
                       result_keys.each_with_index do |result_key, result_key_index|
                         @redis.get(result_key) do |result_json|
-                          _, client_name, check_name = result_key.split(":")
-                          history_key = "history:#{client_name}:#{check_name}"
+                          history_key = result_key.sub(/^result:/, "history:")
                           @redis.lrange(history_key, -21, -1) do |history|
                             history.map! do |status|
                               status.to_i
                             end
                             unless result_json.nil?
+                              client_name = history_key.split(":")[1]
                               check = Sensu::JSON.load(result_json)
                               check[:history] = history
                               @response_content << {:client => client_name, :check => check}


### PR DESCRIPTION
Closes https://github.com/sensu/sensu/issues/1861

The API GET /results endpoint was incorrectly reporting all results under a single client name. Variable scope was the cause (Redis callbacks). This pull-request also improves the /results tests by adding a second client.