### PR TITLE
test for handler extension when logging in filter.rb

### DIFF
--- a/lib/sensu/client/process.rb
+++ b/lib/sensu/client/process.rb
@@ -84,6 +84,7 @@ module Sensu
       #
       # @param check [Hash]
       def publish_check_result(check)
+        check.delete(:source) if check[:source] == ""
         payload = {
           :client => @settings[:client][:name],
           :check => check

--- a/lib/sensu/server/filter.rb
+++ b/lib/sensu/server/filter.rb
@@ -192,7 +192,11 @@ module Sensu
       #   filtered.
       # @yieldparam event [Hash]
       def filter_event(handler, event)
-        details = {:handler => handler, :event => event}
+        handler_info = case handler[:type]
+          when "extension" then handler.definition
+          else handler  
+        end
+        details = {:handler => handler_info, :event => event}
         filter_message = case
         when handling_disabled?(event)
           "event handling disabled for event"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
   s.summary     = "A monitoring framework"
   s.description = "A monitoring framework that aims to be simple, malleable, and scalable."
   s.license     = "MIT"
-  s.has_rdoc    = false
 
   s.add_dependency "eventmachine", "1.2.5"
   s.add_dependency "sensu-json", "2.1.1"

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -68,6 +68,25 @@ describe "Sensu::Client::Process" do
     end
   end
 
+  it "does not send a check result with an empty check source" do
+    async_wrapper do
+      result_queue do |payload|
+        result = Sensu::JSON.load(payload)
+        expect(result[:client]).to eq("i-424242")
+        expect(result[:check][:name]).to eq("test")
+        expect(result[:check][:source]).to be_nil
+        async_done
+      end
+      timer(0.5) do
+        @client.setup_transport do
+          check = result_template[:check]
+          check[:source] = ""
+          @client.publish_check_result(check)
+        end
+      end
+    end
+  end
+
   it "can send a deregistraion check result" do
     async_wrapper do
       result_queue do |payload|


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Test for handler extension when logging from filter.rb.  If handler extension pass only extension description to the logger.

## Related Issue
Proposed Fix for #1872 

## Motivation and Context
Extension class instance variables will leak into logs, leading to huge log messages.
Much safer to just log the handler extension definition.


## How Has This Been Tested?
I haven't tested the proposed fix yet. I'll follow up with testing soon.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
