### PR TITLE
Add validation for ttl attribute in results API

### DIFF
--- a/lib/sensu/api/routes/results.rb
+++ b/lib/sensu/api/routes/results.rb
@@ -16,7 +16,8 @@ module Sensu
             :name => {:type => String, :nil_ok => false, :regex => /\A[\w\.-]+\z/},
             :output => {:type => String, :nil_ok => false},
             :status => {:type => Integer, :nil_ok => true},
-            :source => {:type => String, :nil_ok => true, :regex => /\A[\w\.-]+\z/}
+            :source => {:type => String, :nil_ok => true, :regex => /\A[\w\.-]+\z/},
+            :ttl => {:type => Integer, :nil_ok => true}
           }
           read_data(rules) do |data|
             publish_check_result("sensu-api", data)


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## Description
Adds validation of the `ttl` attribute that can be provided via the `/results` API.

**NOTE**
I noticed that the regex validation for `source` in the `/results` API differs from the regex validation in the sensu-settings project:

https://github.com/sensu/sensu/blob/master/lib/sensu/api/routes/results.rb#L19
https://github.com/sensu/sensu-settings/blob/master/lib/sensu/settings/validators/check.rb#L41

There are also quite a few other fields that are not validated which may be problematic. For example, handlers is not validated to be an array, containing only string values - but that's out of scope for this issue in my opinion.

## Related Issue
Closes #1871.

## Motivation and Context
It's possible to provide an incorrect value for the `ttl` field (e.g. a string, when it needs to be an integer). This can cause the sensu-server process to crash.

## How Has This Been Tested?
Spun up a local environment to reproduce the issue. The `/results` API accepted an event with a string value for the `ttl` attribute. After adding a validator for the `ttl` field, it now rejects the event.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
