### PR TITLE
Add deep_dup method, deep_dup before token substitution

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -836,7 +836,7 @@ module Sensu
           :client => client,
           :check => check
         })
-        proxy_check, unmatched_tokens = object_substitute_tokens(check.dup, client)
+        proxy_check, unmatched_tokens = object_substitute_tokens(deep_dup(check.dup), client)
         if unmatched_tokens.empty?
           proxy_check[:source] ||= client[:name]
           publish_check_request(proxy_check)

--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -51,6 +51,31 @@ module Sensu
       merged
     end
 
+    # Creates a deep dup of basic ruby objects with support for walking
+    # hashes and arrays.
+    #
+    # @param obj [Object]
+    # @return [obj] a dup of the original object.
+    def deep_dup(obj)
+      if obj.class == Hash
+        new_obj = obj.dup
+        new_obj.each do |key, value|
+          new_obj[deep_dup(key)] = deep_dup(value)
+        end
+        new_obj
+      elsif obj.class == Array
+        arr = []
+        obj.each do |item|
+          arr << deep_dup(item)
+        end
+        arr
+      elsif obj.class == String
+        obj.dup
+      else
+        obj
+      end
+    end
+
     # Retrieve the system hostname. If the hostname cannot be
     # determined and an error is thrown, `nil` will be returned.
     #

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -63,6 +63,32 @@ describe "Sensu::Utilities" do
     expect(deep_merge(hash_one, hash_two)).to eq(expected)
   end
 
+  it "can deeply merge a hash" do
+    hash = {
+      :foo => "bar",
+      :baz => 1,
+      :qux => false,
+      :poy => ["one", "two", "three"],
+      :xef => {
+        :foo => "bar"
+      }
+    }
+    expected = {
+      :foo => "bar",
+      :baz => 1,
+      :qux => false,
+      :poy => ["one", "two", "three"],
+      :xef => {
+        :foo => "bar"
+      }
+    }
+    copy = deep_dup(hash)
+    copy[:foo].upcase!
+    copy[:poy][0].upcase!
+    copy[:xef][:foo].upcase!
+    expect(hash).to eq(expected)
+  end
+
   it "can determine the system hostname" do
     hostname = system_hostname
     expect(hostname).to be_kind_of(String)


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## Description
Adds a new `deep_dup` method to handle recursively cloning objects with nested values. Fixes a case in which a shallow duplicated check hash was mutated causing the original check hash to also be mutated.

## Related Issue
Closes #1855 

## Motivation and Context
See #1855 

## How Has This Been Tested?
Reproduced the issue locally. The issue no longer persists after deep-duping the check data. Added specs.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.