### PR TITLE
Delete last_ok when deleting a client

### DIFF
--- a/lib/sensu/api/routes/clients.rb
+++ b/lib/sensu/api/routes/clients.rb
@@ -142,6 +142,7 @@ module Sensu
                             result_key = "#{client_name}:#{check_name}"
                             @redis.del("result:#{result_key}")
                             @redis.del("history:#{result_key}")
+                            @redis.del("history:#{result_key}:last_ok")
                           end
                           @redis.del("result:#{client_name}")
                         end


### PR DESCRIPTION
## Description

This was done for results in #1859 but deleted clients are still having their
last_ok keys left behind to accumulate in Redis over time.

Signed-off-by: Jonathan Hartman <j@hartman.io>

## Related Issue

#1891

## Motivation and Context

Cleaning up some cruft in Redis.

## How Has This Been Tested?

Deployed it to our staging environment and client deletion works now.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.