### PR TITLE
Check result deletion API endpoint

### DIFF
--- a/lib/sensu/api/routes.rb
+++ b/lib/sensu/api/routes.rb
@@ -76,6 +76,7 @@ module Sensu
         ],
         DELETE_METHOD => [
           [CLIENT_URI, :delete_client],
+          [CHECK_URI, :delete_check],
           [EVENT_URI, :delete_event],
           [AGGREGATE_URI, :delete_aggregate],
           [STASH_URI, :delete_stash],

--- a/lib/sensu/api/routes/checks.rb
+++ b/lib/sensu/api/routes/checks.rb
@@ -25,18 +25,14 @@ module Sensu
 
         # DELETE /checks/:check_name
         def delete_check
-          # history:*:check_name
-          # history:*:check_name:last_ok
-          # result:*:check_name
           check_name = parse_uri(CHECK_URI).first
-          @redis.keys("result:*:#{check_name}") do |result_keys|
-            @redis.keys("history:*:#{check_name}") do |history_keys|
-              @redis.keys("history:*:#{check_name}:last_ok") do |last_ok_keys|
-                keys = result_keys.concat(history_keys).concat(last_ok_keys)
-                keys.each do |key|
-                  @redis.del(key)
-                end
-              end
+          @redis.smembers("clients") do |clients|
+            result_keys = clients.map {|client_name| "result:#{client_name}:#{check_name}"}
+            history_keys = clients.map {|client_name| "history:#{client_name}:#{check_name}"}
+            last_ok_keys = clients.map {|client_name| "history:#{client_name}:#{check_name}:last_ok"}
+            keys = result_keys.concat(history_keys).concat(last_ok_keys)
+            keys.each do |key|
+              @redis.del(key)
             end
           end
           @response_content = {:issued => Time.now.to_i}

--- a/lib/sensu/api/routes/checks.rb
+++ b/lib/sensu/api/routes/checks.rb
@@ -22,6 +22,26 @@ module Sensu
             not_found!
           end
         end
+
+        # DELETE /checks/:check_name
+        def delete_check
+          # history:*:check_name
+          # history:*:check_name:last_ok
+          # result:*:check_name
+          check_name = parse_uri(CHECK_URI).first
+          @redis.keys("result:*:#{check_name}") do |result_keys|
+            @redis.keys("history:*:#{check_name}") do |history_keys|
+              @redis.keys("history:*:#{check_name}:last_ok") do |last_ok_keys|
+                keys = result_keys.concat(history_keys).concat(last_ok_keys)
+                keys.each do |key|
+                  @redis.del(key)
+                end
+              end
+            end
+          end
+          @response_content = {:issued => Time.now.to_i}
+          accepted!
+        end
       end
     end
   end


### PR DESCRIPTION
## Description
Provides an endpoint to delete check results & history (for all clients) for a given check name.

This will require https://github.com/sensu/sensu-redis/pull/21 to be merged and a new version of sensu-redis to be cut.

A few questions,

1) Do we want to delete just results and not history / last_ok?
2) Do we want to use `DELETE /checks/:check_name` or would a different endpoint make more sense?

## Related Issue
Fixes #1893.

## Motivation and Context
See #1893.

## How Has This Been Tested?
Tested manually & wrote a new spec.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
