### PR TITLE
Replace proxy check result command with original definition

### DIFF
--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -703,6 +703,9 @@ module Sensu
             end
             check[:type] ||= STANDARD_CHECK_TYPE
             check[:origin] = result[:client] if check[:source]
+            if @settings.check_exists?(check[:name].to_sym) && client[:type] == "proxy"
+              check[:command] = @settings[:checks][check[:name].to_sym][:command]
+            end
             aggregate_check_result(client, check) if check[:aggregates] || check[:aggregate]
             store_check_result(client, check) do
               create_event(client, check) do |event|

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -703,7 +703,7 @@ module Sensu
             end
             check[:type] ||= STANDARD_CHECK_TYPE
             check[:origin] = result[:client] if check[:source]
-            if @settings.check_exists?(check[:name].to_sym) && client[:type] == "proxy"
+            if @settings.check_exists?(check[:name]) && client[:type] == "proxy"
               check[:command] = @settings[:checks][check[:name].to_sym][:command]
             end
             aggregate_check_result(client, check) if check[:aggregates] || check[:aggregate]

--- a/spec/config.json
+++ b/spec/config.json
@@ -179,7 +179,7 @@
       ]
     },
     "unpublished_proxy": {
-      "command": "/bin/true",
+      "command": "echo :::address::: && exit 1",
       "publish": false,
       "subscribers": [
         "test"

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -208,22 +208,13 @@ describe "Sensu::Server::Process" do
       @server.setup_redis do
         redis.flushdb do
           @server.setup_transport do
-            check = check_template
-            check[:command] = "echo :::address::: && exit 1"
-            check[:subscribers] = ["test"]
-            check[:proxy_requests] = {
-              :client_attributes => {
-                :name => "i-424242",
-                :subscriptions => "eval: value.include?('test')"
-              }
-            }
-            @server.settings[:checks][check[:name].to_sym] = check
             result = result_template
+            result[:check][:name] = "unpublished_proxy"
             result[:check][:command] = "echo 127.0.0.1 && exit 1"
             result[:check][:source] = "i-424242"
             @server.process_check_result(result)
             timer(1) do
-              redis.hget("events:i-424242", "test") do |event_json|
+              redis.hget("events:i-424242", "unpublished_proxy") do |event_json|
                 event = Sensu::JSON.load(event_json)
                 expect(event[:check][:command]).to eq("echo :::address::: && exit 1")
                 async_done

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -203,6 +203,38 @@ describe "Sensu::Server::Process" do
     end
   end
 
+  it "can process results from proxy clients" do
+    async_wrapper do
+      @server.setup_redis do
+        redis.flushdb do
+          @server.setup_transport do
+            check = check_template
+            check[:command] = "echo :::address::: && exit 1"
+            check[:subscribers] = ["test"]
+            check[:proxy_requests] = {
+              :client_attributes => {
+                :name => "i-424242",
+                :subscriptions => "eval: value.include?('test')"
+              }
+            }
+            @server.settings[:checks][check[:name].to_sym] = check
+            result = result_template
+            result[:check][:command] = "echo 127.0.0.1 && exit 1"
+            result[:check][:source] = "i-424242"
+            @server.process_check_result(result)
+            timer(1) do
+              redis.hget("events:i-424242", "test") do |event_json|
+                event = Sensu::JSON.load(event_json)
+                expect(event[:check][:command]).to eq("echo :::address::: && exit 1")
+                async_done
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
   it "can process results with flap detection" do
     FileUtils.rm_rf("/tmp/sensu_event")
     expect(File.exists?("/tmp/sensu_event")).to eq(false)


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## Description
Modifies the command in check results from proxy clients with the original definition.

## Related Issue
Fixes #1869.

## Motivation and Context
The command in a check result from a client proxy can contain sensitive information post-token substitution. This change will reset the command to contain the original tokens.

## How Has This Been Tested?
Wrote a new spec.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
