### PR TITLE
Redact attributes in GET /clients & /clients/:client routes

### DIFF
--- a/lib/sensu/api/routes/clients.rb
+++ b/lib/sensu/api/routes/clients.rb
@@ -42,7 +42,8 @@ module Sensu
               clients.each_with_index do |client_name, index|
                 @redis.get("client:#{client_name}") do |client_json|
                   unless client_json.nil?
-                    @response_content << Sensu::JSON.load(client_json)
+                    client = Sensu::JSON.load(client_json)
+                    @response_content << redact_sensitive(client, client[:redact])
                   else
                     @logger.error("client data missing from registry", :client_name => client_name)
                     @redis.srem("clients", client_name)
@@ -63,7 +64,8 @@ module Sensu
           client_name = parse_uri(CLIENT_URI).first
           @redis.get("client:#{client_name}") do |client_json|
             unless client_json.nil?
-              @response_content = Sensu::JSON.load(client_json)
+              client = Sensu::JSON.load(client_json)
+              @response_content = redact_sensitive(client, client[:redact])
               respond
             else
               not_found!


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## Description
Adds support for redacted attributes in the `GET /clients` and `GET /clients/:client` routes.

## Related Issue
Fixes #1869.

## Motivation and Context
Sensitive information should not be sent in API responses.

## How Has This Been Tested?
Added specs in a TDD fashion.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
