### PR TITLE
Fix Redis Sentinel DNS resolution error handling

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -9,7 +9,7 @@ gem "sensu-extension", "1.5.2"
 gem "sensu-extensions", "1.10.0"
 gem "sensu-transport", "8.2.0"
 gem "sensu-spawn", "2.5.0"
-gem "sensu-redis", "2.3.0"
+gem "sensu-redis", "2.4.0"
 
 require "time"
 require "uri"

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sensu-extensions", "1.10.0"
   s.add_dependency "sensu-transport", "8.2.0"
   s.add_dependency "sensu-spawn", "2.5.0"
-  s.add_dependency "sensu-redis", "2.3.0"
+  s.add_dependency "sensu-redis", "2.4.0"
   s.add_dependency "em-http-server", "0.1.8"
   s.add_dependency "em-http-request", "1.1.5"
   s.add_dependency "parse-cron", "0.1.4"


### PR DESCRIPTION
This pull-request bumps sensu-redis to 2.4.0, fixing Redis Sentinel DNS resolution error handling.

![dog-dog](https://user-images.githubusercontent.com/149630/49675205-819db680-fa29-11e8-8c47-36b3e7758497.jpg)
