### PR TITLE
Add response body to health endpoint

### DIFF
--- a/lib/sensu/api/routes/health.rb
+++ b/lib/sensu/api/routes/health.rb
@@ -10,22 +10,32 @@ module Sensu
 
         # GET /health
         def get_health
+          @response_content = []
           if @redis.connected? && @transport.connected?
-            healthy = []
             min_consumers = integer_parameter(@params[:consumers])
             max_messages = integer_parameter(@params[:messages])
             transport_info do |info|
               if min_consumers
-                healthy << (info[:keepalives][:consumers] >= min_consumers)
-                healthy << (info[:results][:consumers] >= min_consumers)
+                if info[:keepalives][:consumers] < min_consumers
+                  @response_content << "keepalive consumers (#{info[:keepalives][:consumers]}) less than min_consumers (#{min_consumers})"
+                end
+                if info[:results][:consumers] < min_consumers
+                  @response_content << "result consumers (#{info[:results][:consumers]}) less than min_consumers (#{min_consumers})"
+                end
               end
               if max_messages
-                healthy << (info[:keepalives][:messages] <= max_messages)
-                healthy << (info[:results][:messages] <= max_messages)
+                if info[:keepalives][:messages] > max_messages
+                  @response_content << "keepalive messages (#{info[:keepalives][:messages]}) greater than max_messages (#{max_messages})"
+                end
+                if info[:results][:messages] > max_messages
+                  @response_content << "result messages (#{info[:results][:messages]}) greater than max_messages (#{max_messages})"
+                end
               end
-              healthy.all? ? no_content! : precondition_failed!
+              @response_content.empty? ? no_content! : precondition_failed!
             end
           else
+            @response_content << "not connected to redis" unless @redis.connected?
+            @response_content << "not connected to transport" unless @transport.connected?
             precondition_failed!
           end
         end

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -117,7 +117,7 @@ describe "Sensu::API::Process" do
         expect(body).to be_empty
         http_request(4567, "/health?consumers=1000") do |http, body|
           expect(http.response_header.status).to eq(412)
-          expect(body).to be_empty
+          expect(body).to eq(["keepalive consumers (0) less than min_consumers (1000)", "result consumers (0) less than min_consumers (1000)"])
           http_request(4567, "/health?consumers=1000&messages=1000") do |http, body|
             expect(http.response_header.status).to eq(412)
             async_done


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## Description
Adds a new response body to the `/health` endpoint which, in the event that the health check fails, will return a list of reasons why the health check failed.

## Related Issue
Fixes #1880.

## Motivation and Context
See #1880.

## How Has This Been Tested?
rspec tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
