### PR TITLE
Only split on first pipe in token sub

### DIFF
--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -190,7 +190,7 @@ module Sensu
         :replace => ""
       })
       substituted = encoded_tokens.gsub(/:::([^:].*?):::/) do
-        token, default = $1.to_s.split("|", -1)
+        token, default = $1.to_s.split("|", 2)
         path = token.split(".").map(&:to_sym)
         matched = find_attribute_value(attributes, path, default)
         if matched.nil?

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -148,6 +148,7 @@ describe "Sensu::Utilities" do
     string << " :::missing|::: :::missing::: :::nested.attribute:::::::nested.attribute:::"
     string << " :::empty|localhost::: :::empty.hash|localhost:8080:::"
     string << " :::foo\255|default:::"
+    string << " :::empty|default|with_pipe:::"
     attributes = {
       :nested => {
         :attribute => true
@@ -156,7 +157,7 @@ describe "Sensu::Utilities" do
       :foo => true
     }
     result, unmatched_tokens = substitute_tokens(string, attributes)
-    expect(result).to eq("true default   true:true localhost localhost:8080 true")
+    expect(result).to eq("true default   true:true localhost localhost:8080 true default|with_pipe")
     expect(unmatched_tokens).to eq(["missing"])
   end
 


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## Description
Only split on the first instance of `|` in token substitution to allow for pipes to be used in default values (e.g. regex).

## Related Issue
Fixes #1932.

## Motivation and Context
See #1932.

## How Has This Been Tested?
Wrote a new spec, existing specs pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
