### PR TITLE
deep_dup check attrs in api token subs

### DIFF
--- a/lib/sensu/api/utilities/publish_check_request.rb
+++ b/lib/sensu/api/utilities/publish_check_request.rb
@@ -82,7 +82,7 @@ module Sensu
                         :client => client,
                         :check => check
                       })
-                      proxy_check, unmatched_tokens = object_substitute_tokens(check.dup, client)
+                      proxy_check, unmatched_tokens = object_substitute_tokens(deep_dup(check.dup), client)
                       if unmatched_tokens.empty?
                         proxy_check[:source] ||= client[:name]
                         publish_check_request(proxy_check)


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## Description
Runs check attributes through `deep_dup()` before running token substitution on check attributes in Sensu API.

## Related Issue
Fixes #1908.

## Motivation and Context
See #1908.

## How Has This Been Tested?
Paired with @cwjohnston to reproduce the issue. Confirmed that this PR fixes the issue.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
