### PR TITLE
EventMachine global catch-all error handler

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -51,7 +51,9 @@ module Sensu
       unless EM::reactor_running?
         EM::epoll
         EM::set_max_timers(200000)
-        global_error_handler
+        EM::error_handler do |error|
+          unexpected_error(error)
+        end
       end
       setup_logger(options)
       load_settings(options)
@@ -60,19 +62,6 @@ module Sensu
         setup_spawn
       end
       setup_process(options)
-    end
-
-    # Set up the EM global catch-all error handler. See
-    # unexpected_error() for details.
-    def global_error_handler
-      if @settings && @settings[:sensu][:global_error_handler]
-        @logger.warn("global catch-all error handling enabled")
-      else
-        @logger.debug("global catch-all error handling not enabled")
-      end
-      EM::error_handler do |error|
-        unexpected_error(error)
-      end
     end
 
     # Handle an unexpected error. This method is used for EM global

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -95,7 +95,7 @@ module Sensu
           })
         else
           puts "global catch-all error handling enabled"
-          puts "unexpected error - please address this immediately: #{error.to_s}\n#{backtrace}"
+          puts "unexpected error - please address this immediately: #{error.to_s}\n#{error.class}\n#{backtrace}"
         end
       else
         raise error

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -78,6 +78,7 @@ module Sensu
         if @logger
           @logger.fatal("unexpected error - please address this immediately", {
             :error => error.to_s,
+            :error_class => error.class,
             :backtrace => backtrace
           })
         else

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.7"
 
 gem "sensu-json", "2.1.1"
 gem "sensu-logger", "1.2.2"
-gem "sensu-settings", "10.14.0"
+gem "sensu-settings", "10.15.0"
 gem "sensu-extension", "1.5.2"
 gem "sensu-extensions", "1.10.0"
 gem "sensu-transport", "8.2.0"

--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -73,17 +73,18 @@ module Sensu
     #
     # @param error [Object]
     def unexpected_error(error)
-      unless @settings && @settings[:sensu][:global_error_handler]
-        raise error
-      end
-      backtrace = error.backtrace.join("\n")
-      if @logger
-        @logger.error("unexpected error", {
-          :error => error.to_s,
-          :backtrace => backtrace
-        })
+      if @settings && @settings[:sensu][:global_error_handler]
+        backtrace = error.backtrace.join("\n")
+        if @logger
+          @logger.fatal("unexpected error - please address this immediately", {
+            :error => error.to_s,
+            :backtrace => backtrace
+          })
+        else
+          puts "unexpected error - please address this immediately: #{error.to_s}\n#{backtrace}"
+        end
       else
-        puts "unexpected error: #{error.to_s}\n#{backtrace}"
+        raise error
       end
     end
 

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.7"
   s.add_dependency "sensu-json", "2.1.1"
   s.add_dependency "sensu-logger", "1.2.2"
-  s.add_dependency "sensu-settings", "10.14.0"
+  s.add_dependency "sensu-settings", "10.15.0"
   s.add_dependency "sensu-extension", "1.5.2"
   s.add_dependency "sensu-extensions", "1.10.0"
   s.add_dependency "sensu-transport", "8.2.0"


### PR DESCRIPTION
This pull-request introduces an EventMachine global catch-all error handler. It's an opt-in feature, it's horrible for many reasons.

Possible solution for https://github.com/sensu/sensu/issues/1885