### PR TITLE
Clean up server registry entries that failed to expire

### DIFF
--- a/lib/sensu/api/utilities/servers_info.rb
+++ b/lib/sensu/api/utilities/servers_info.rb
@@ -17,7 +17,7 @@ module Sensu
                       if server[:timestamp] >= (Time.now.to_i - 30)
                         info << server
                       else
-                        @redis.del(server_id) do
+                        @redis.del("server:#{server_id}") do
                           @redis.srem("servers", server_id)
                         end
                       end

--- a/lib/sensu/api/utilities/servers_info.rb
+++ b/lib/sensu/api/utilities/servers_info.rb
@@ -13,7 +13,14 @@ module Sensu
                 servers.each_with_index do |server_id, index|
                   @redis.get("server:#{server_id}") do |server_json|
                     unless server_json.nil?
-                      info << Sensu::JSON.load(server_json)
+                      server = Sensu::JSON.load(server_json)
+                      if server[:timestamp] >= (Time.now.to_i - 30)
+                        info << server
+                      else
+                        @redis.del(server_id) do
+                          @redis.srem("servers", server_id)
+                        end
+                      end
                     else
                       @redis.srem("servers", server_id)
                     end

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -93,20 +93,28 @@ describe "Sensu::API::Process" do
   end
 
   it "can provide basic version and health information" do
-    api_test do
-      http_request(4567, "/info") do |http, body|
-        expect(http.response_header.status).to eq(200)
-        expect(body[:sensu][:version]).to eq(Sensu::VERSION)
-        expect(body[:sensu][:settings][:hexdigest]).to be_kind_of(String)
-        expect(body[:redis][:connected]).to be(true)
-        expect(body[:transport][:name]).to eq("rabbitmq")
-        expect(body[:transport][:connected]).to be(true)
-        expect(body[:transport][:keepalives][:messages]).to be_kind_of(Integer)
-        expect(body[:transport][:keepalives][:consumers]).to be_kind_of(Integer)
-        expect(body[:transport][:results][:messages]).to be_kind_of(Integer)
-        expect(body[:transport][:results][:consumers]).to be_kind_of(Integer)
-        expect(body[:servers]).to be_kind_of(Array)
-        async_done
+    @server = Sensu::Server::Process.new(options)
+    async_wrapper do
+      @server.setup_connections do
+        @server.update_server_registry do
+          api_test do
+            http_request(4567, "/info") do |http, body|
+              expect(http.response_header.status).to eq(200)
+              expect(body[:sensu][:version]).to eq(Sensu::VERSION)
+              expect(body[:sensu][:settings][:hexdigest]).to be_kind_of(String)
+              expect(body[:redis][:connected]).to be(true)
+              expect(body[:transport][:name]).to eq("rabbitmq")
+              expect(body[:transport][:connected]).to be(true)
+              expect(body[:transport][:keepalives][:messages]).to be_kind_of(Integer)
+              expect(body[:transport][:keepalives][:consumers]).to be_kind_of(Integer)
+              expect(body[:transport][:results][:messages]).to be_kind_of(Integer)
+              expect(body[:transport][:results][:consumers]).to be_kind_of(Integer)
+              expect(body[:servers]).to be_kind_of(Array)
+              expect(body[:servers].length).to eq(1)
+              async_done
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This pull-request includes an API /info change to clean up Sensu Server registry entries that failed to expire (Redis) after 30 seconds without updates.

Closes: https://github.com/sensu/sensu/issues/1922

Signed-off-by: Sean Porter <portertech@gmail.com>