### PR TITLE
Update sensu-install

### DIFF
--- a/exe/sensu-install
+++ b/exe/sensu-install
@@ -71,7 +71,7 @@ module Sensu
         gem_name, gem_version = raw_gem.split(":")
         gem_command = "gem install #{gem_name}"
         gem_command << " --version '#{gem_version}'" if gem_version
-        gem_command << " --no-ri --no-rdoc"
+        gem_command << " --no-document"
         gem_command << " --verbose" if options[:verbose]
         gem_command << " --source #{options[:source]}" if options[:source]
         gem_command << " --http-proxy #{options[:proxy]}" if options[:proxy]


### PR DESCRIPTION
Replace deprecated gem options (--no-ri --no-rdoc) with --no-document in sensu-install

## Description
Replace deprecated gem options (--no-ri --no-rdoc) with --no-document in sensu-install

## Related Issue
None yet... but fails to install plugins using the latest sensu 1.7.0 and ruby

## Motivation and Context
sensu-install fails to install sensu plugins using the latest ruby version

## How Has This Been Tested?
tested using own dockerfile / test environment and replacing options inside sensu-install manually.

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
