### PR TITLE
updating outdated parse-cron gem

### DIFF
--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -1,8 +1,8 @@
-gem "parse-cron", "0.1.4"
+gem "parse_cron", "0.1.6"
 
 require "securerandom"
 require "sensu/sandbox"
-require "parse-cron"
+require "parse_cron"
 require "socket"
 
 module Sensu

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sensu-redis", "2.4.0"
   s.add_dependency "em-http-server", "0.1.8"
   s.add_dependency "em-http-request", "1.1.5"
-  s.add_dependency "parse-cron", "0.1.4"
+  s.add_dependency "parse_cron", "0.1.6"
 
   s.add_development_dependency "rake", "10.5.0"
   s.add_development_dependency "rspec", "~> 3.0.0"

--- a/spec/client/process_spec.rb
+++ b/spec/client/process_spec.rb
@@ -518,7 +518,7 @@ describe "Sensu::Client::Process" do
   it "can schedule standalone check execution using the cron syntax" do
     async_wrapper do
       check = check_template
-      check[:cron] = "* * * * *"
+      check[:cron] = "* * * * * * *"
       @client.schedule_checks([check])
       expect(@client.instance_variable_get(:@timers)[:run].size).to eq(1)
       async_done

--- a/spec/config.json
+++ b/spec/config.json
@@ -195,7 +195,7 @@
       "subscribers": [
         "test"
       ],
-      "cron": "* * * * *"
+      "cron": "* * * * * * *"
     },
     "hooked": {
       "command": "echo FAIL && exit 1",

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -894,7 +894,7 @@ describe "Sensu::Server::Process" do
   it "can schedule check request publishing using the cron syntax" do
     async_wrapper do
       check = check_template
-      check[:cron] = "* * * * *"
+      check[:cron] = "* * * * * * *"
       @server.schedule_checks([check])
       expect(@server.instance_variable_get(:@timers)[:tasks][:check_request_publisher].size).to eq(1)
       async_done

--- a/spec/server/process_spec.rb
+++ b/spec/server/process_spec.rb
@@ -842,7 +842,7 @@ describe "Sensu::Server::Process" do
                 timer(1) do
                   check = check_template
                   check.delete(:interval)
-                  check[:cron] = "* * * * *"
+                  check[:cron] = "* * * * * * *"
                   check[:command] = "echo :::address::: && exit 1"
                   check[:subscribers] = ["test"]
                   check[:proxy_requests] = {


### PR DESCRIPTION
https://github.com/oscar123mendoza/parse_cron

## Description
I am updating the gem to be able to handle 5, 6, and 7 field cron jobs. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
I use dkron as a cron job scheduler and all crons are written into 7 digit cron jobs and this would add that support for sensu.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
