### PR TITLE
Bump sensu-transport to 8.3.0

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -7,7 +7,7 @@ gem "sensu-logger", "1.2.2"
 gem "sensu-settings", "10.15.0"
 gem "sensu-extension", "1.5.2"
 gem "sensu-extensions", "1.11.0"
-gem "sensu-transport", "8.2.0"
+gem "sensu-transport", "8.3.0"
 gem "sensu-spawn", "2.5.0"
 gem "sensu-redis", "2.4.0"
 

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sensu-settings", "10.15.0"
   s.add_dependency "sensu-extension", "1.5.2"
   s.add_dependency "sensu-extensions", "1.11.0"
-  s.add_dependency "sensu-transport", "8.2.0"
+  s.add_dependency "sensu-transport", "8.3.0"
   s.add_dependency "sensu-spawn", "2.5.0"
   s.add_dependency "sensu-redis", "2.4.0"
   s.add_dependency "em-http-server", "0.1.8"


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## Description
Bump `sensu-transport` to `8.3.0` to add reconnect call when publishing to a transport in a disconnected state.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
