### PR TITLE
Configurable server results pipe

### DIFF
--- a/lib/sensu/daemon.rb
+++ b/lib/sensu/daemon.rb
@@ -4,7 +4,7 @@ gem "eventmachine", "1.2.7"
 
 gem "sensu-json", "2.1.1"
 gem "sensu-logger", "1.2.2"
-gem "sensu-settings", "10.15.0"
+gem "sensu-settings", "10.16.0"
 gem "sensu-extension", "1.5.2"
 gem "sensu-extensions", "1.11.0"
 gem "sensu-transport", "8.3.0"

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -733,7 +733,11 @@ module Sensu
       # mechanism. Result JSON parsing errors are logged.
       def setup_results
         @logger.debug("subscribing to results")
-        @transport.subscribe(:direct, "results", "results", :ack => true) do |message_info, message|
+        results_pipe = "results"
+        if @settings[:sensu][:server] && @settings[:sensu][:server][:results_pipe]
+          results_pipe = @settings[:sensu][:server][:results_pipe]
+        end
+        @transport.subscribe(:direct, results_pipe, "results", :ack => true) do |message_info, message|
           begin
             result = Sensu::JSON.load(message)
             @logger.debug("received result", :result => result)

--- a/lib/sensu/server/process.rb
+++ b/lib/sensu/server/process.rb
@@ -183,8 +183,12 @@ module Sensu
       # ensure the client registry is updated successfully. Keepalive
       # JSON parsing errors are logged.
       def setup_keepalives
-        @logger.debug("subscribing to keepalives")
-        @transport.subscribe(:direct, "keepalives", "keepalives", :ack => true) do |message_info, message|
+        keepalives_pipe = "keepalives"
+        if @settings[:sensu][:server] && @settings[:sensu][:server][:keepalives_pipe]
+          keepalives_pipe = @settings[:sensu][:server][:keepalives_pipe]
+        end
+        @logger.debug("subscribing to keepalives", :pipe => keepalives_pipe)
+        @transport.subscribe(:direct, keepalives_pipe, "keepalives", :ack => true) do |message_info, message|
           @logger.debug("received keepalive", :message => message)
           begin
             client = Sensu::JSON.load(message)
@@ -732,11 +736,11 @@ module Sensu
       # of the EventMachine reactor (event loop), as a flow control
       # mechanism. Result JSON parsing errors are logged.
       def setup_results
-        @logger.debug("subscribing to results")
         results_pipe = "results"
         if @settings[:sensu][:server] && @settings[:sensu][:server][:results_pipe]
           results_pipe = @settings[:sensu][:server][:results_pipe]
         end
+        @logger.debug("subscribing to results", :pipe => results_pipe)
         @transport.subscribe(:direct, results_pipe, "results", :ack => true) do |message_info, message|
           begin
             result = Sensu::JSON.load(message)

--- a/sensu.gemspec
+++ b/sensu.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency "eventmachine", "1.2.7"
   s.add_dependency "sensu-json", "2.1.1"
   s.add_dependency "sensu-logger", "1.2.2"
-  s.add_dependency "sensu-settings", "10.15.0"
+  s.add_dependency "sensu-settings", "10.16.0"
   s.add_dependency "sensu-extension", "1.5.2"
   s.add_dependency "sensu-extensions", "1.11.0"
   s.add_dependency "sensu-transport", "8.3.0"


### PR DESCRIPTION
This pull-request adds the ability to configure the Sensu Transport pipe used for consuming check results. A super power user tool, only intended to be used when deploying an active-active site setup (e.g. using the RabbitMQ shovel plugin).

Example RabbitMQ configuration:

```
[
    {rabbitmq_shovel,
       [{shovels,
         [{site_a_results,
           [{sources,      [{broker, "amqp://sensu:secret@site-a:5672/%2Fsensu"},
                            {declarations,
                               [{'exchange.declare',
                                       [{exchange, <<"results">>},
                                        {type, <<"direct">>}]},
                                {'exchange.declare',
                                       [{exchange, <<"site-a-results">>},
                                        {type, <<"direct">>}]},
                                {'exchange.bind',
                                       [{source, <<"results">>},
                                        {destination, <<"site-a-results">>}]},
                                {'queue.declare',
                                       [{queue, <<"shovel-site-a-results">>}]},
                                {'queue.bind',
                                       [{exchange, <<"results">>},
                                        {queue, <<"shovel-site-a-results">>}]}
                               ]}]},
            {destinations, [{broker, "amqp://sensu:secret@site-b:5672/%2Fsensu"},
                            {declarations,
                               [{'exchange.declare',
                                       [{exchange, <<"site-b-results">>},
                                        {type, <<"direct">>}]},
                                {'exchange.bind',
                                       [{source, <<"results">>},
                                        {destination, <<"site-b-results">>}]}
                               ]}]},
            {queue, <<"shovel-site-a-results">>},
            {ack_mode, on_confirm},
            {publish_properties, [{delivery_mode, 2}]},
            {publish_fields, [{exchange, <<"site-b-results">>}]},
            {reconnect_delay, 5}
           ]}
          ]
        }]
     }
].
```

```
[
    {rabbitmq_shovel,
       [{shovels,
         [{site_b_results,
           [{sources,      [{broker, "amqp://sensu:secret@site-b:5672/%2Fsensu"},
                            {declarations,
                               [{'exchange.declare',
                                       [{exchange, <<"results">>},
                                        {type, <<"direct">>}]},
                                {'exchange.declare',
                                       [{exchange, <<"site-b-results">>},
                                        {type, <<"direct">>}]},
                                {'exchange.bind',
                                       [{source, <<"results">>},
                                        {destination, <<"site-b-results">>}]},
                                {'queue.declare',
                                       [{queue, <<"shovel-site-b-results">>}]},
                                {'queue.bind',
                                       [{exchange, <<"results">>},
                                        {queue, <<"shovel-site-b-results">>}]}
                               ]}]},
            {destinations, [{broker, "amqp://sensu:secret@site-a:5672/%2Fsensu"},
                            {declarations,
                               [{'exchange.declare',
                                       [{exchange, <<"site-a-results">>},
                                        {type, <<"direct">>}]},
                                {'exchange.bind',
                                       [{source, <<"results">>},
                                        {destination, <<"site-a-results">>}]}
                               ]}]},
            {queue, <<"shovel-site-b-results">>},
            {ack_mode, on_confirm},
            {publish_properties, [{delivery_mode, 2}]},
            {publish_fields, [{exchange, <<"site-a-results">>}]},
            {reconnect_delay, 5}
           ]}
          ]
        }]
     }
].
```

Example Sensu configurations:

```
{
    "sensu": {
        "server": {
            "results_pipe": "site-a-results"
        }
    }
}
```

```
{
    "sensu": {
        "server": {
            "results_pipe": "site-b-results"
        }
    }
}
```