### PR TITLE
Set default pipe handler timeout

### DIFF
--- a/lib/sensu/server/handle.rb
+++ b/lib/sensu/server/handle.rb
@@ -39,7 +39,10 @@ module Sensu
       #   process via STDIN.
       # @param event_id [String] event UUID
       def pipe_handler(handler, event_data, event_id)
-        options = {:data => event_data, :timeout => handler[:timeout]}
+        options = {
+          :data => event_data,
+          :timeout => handler[:timeout] || 10
+        }
         Spawn.process(handler[:command], options) do |output, status|
           log_level = status == 0 ? :info : :error
           @logger.send(log_level, "handler output", {


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## Description
Sets the default pipe handler timeout to 10 seconds.

## Motivation and Context
Sensu can indefinitely wait for child processes to quit during a clean shutdown. In the event that the parent process is forcefully killed while child processes are still running, the ports that Sensu listen on can remain "in use" preventing a restart. The only workaround is to manually kill the child processes.

Setting a default pipe handler timeout will help prevent this case from happening. Secondarily, our documentation already states that the default timeout is 10 for pipe handlers.

## How Has This Been Tested?
Tested that a pipe handler (golang app that sleeps for 60 seconds) was killed after 10 seconds of execution.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
