### PR TITLE
HTTP response 204 'no content' should actually have no content

### DIFF
--- a/lib/sensu/api/http_handler.rb
+++ b/lib/sensu/api/http_handler.rb
@@ -281,6 +281,7 @@ module Sensu
       def no_content!
         @response_status = 204
         @response_status_string = "No Content"
+        @response_content = nil
         respond
       end
 

--- a/spec/api/process_spec.rb
+++ b/spec/api/process_spec.rb
@@ -124,7 +124,7 @@ describe "Sensu::API::Process" do
       http_request(4567, "/health?consumers=0&messages=1000") do |http, body|
         expect(http.response_header.status).to eq(204)
         expect(http.response_header.http_reason).to eq('No Content')
-        expect(body).to be_empty
+        expect(body).to be_nil
         http_request(4567, "/health?consumers=1000") do |http, body|
           expect(http.response_header.status).to eq(412)
           expect(body).to eq(["keepalive consumers (0) less than min_consumers (1000)", "result consumers (0) less than min_consumers (1000)"])
@@ -1126,7 +1126,7 @@ describe "Sensu::API::Process" do
       http_request(4567, "/stash/test/test", :delete) do |http, body|
         expect(http.response_header.status).to eq(204)
         expect(http.response_header.http_reason).to eq('No Content')
-        expect(body).to be_empty
+        expect(body).to be_nil
         redis.exists("stash:test/test") do |exists|
           expect(exists).to be(false)
           async_done
@@ -1190,7 +1190,7 @@ describe "Sensu::API::Process" do
           http_request(4567, "/aggregates/test", :delete) do |http, body|
             expect(http.response_header.status).to eq(204)
             expect(http.response_header.http_reason).to eq('No Content')
-            expect(body).to be_empty
+            expect(body).to be_nil
             redis.sismember("aggregates", "test") do |exists|
               expect(exists).to be(false)
               async_done
@@ -1212,7 +1212,7 @@ describe "Sensu::API::Process" do
           http_request(4567, "/aggregates/TEST", :delete) do |http, body|
             expect(http.response_header.status).to eq(204)
             expect(http.response_header.http_reason).to eq('No Content')
-            expect(body).to be_empty
+            expect(body).to be_nil
             redis.sismember("aggregates", "TEST") do |exists|
               expect(exists).to be(false)
               async_done
@@ -1629,7 +1629,7 @@ describe "Sensu::API::Process" do
       http_request(4567, "/results/i-424242/test", :delete) do |http, body|
         expect(http.response_header.status).to eq(204)
         expect(http.response_header.http_reason).to eq('No Content')
-        expect(body).to be_empty
+        expect(body).to be_nil
         async_done
       end
     end


### PR DESCRIPTION
Signed-off-by: Nathan Haneysmith <nathan@chef.io>

<!--- Provide a general summary of your changes in the Title above -->
When preparing a HTTP 204 response, nil out content.

## Description
<!--- Describe your changes in detail -->
Currently any value in @response_content will be returned in a 204 response. This can be see in the health api endpoint, where a "good" result returns the value of @response_content, which is an empty array "[]" which then gets JSON.dump'd into the response content as "[]". This should properly be "no content" and not a json representation of an empty array.

This came up as I was attempting to setup AWS ALB host group healthcheck on the health endpoint. The non-empty response while returning status code 204 (no response) causes an error.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fix for #1961 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will bring us in line with RFC for HTTP 204 and allow AWS ALB Target Group healthchecks to appropriately call the /health endpoint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
