### PR TITLE
subdue default times do not provide enough resolution

### DIFF
--- a/lib/sensu/utilities.rb
+++ b/lib/sensu/utilities.rb
@@ -8,6 +8,7 @@ require "socket"
 module Sensu
   module Utilities
     EVAL_PREFIX = "eval:".freeze
+    NANOSECOND_RESOLUTION = 9.freeze
 
     # Determine if Sensu is being tested, using the process name.
     # Sensu is being test if the process name is "rspec",
@@ -334,9 +335,9 @@ module Sensu
         end_time = Time.parse(condition[:end])
         if end_time < begin_time
           if Time.now < end_time
-            begin_time = Time.new(*begin_time.strftime("%Y %m %d 00 00 00 %:z").split("\s"))
+            begin_time = Time.parse(*begin_time.strftime("%Y-%m-%d 00:00:00.#{Array.new(NANOSECOND_RESOLUTION, 0).join} %:z"))
           else
-            end_time = Time.new(*end_time.strftime("%Y %m %d 23 59 59 %:z").split("\s"))
+            end_time = Time.parse(*end_time.strftime("%Y-%m-%d 23:59:59.#{Array.new(NANOSECOND_RESOLUTION, 9).join} %:z"))
           end
         end
         Time.now >= begin_time && Time.now <= end_time


### PR DESCRIPTION
When subdue end occurs before begin the default values that sensu provides doesn’t extend to milliseconds which is causing issues with the days rolling over. Provide sub-second resolution to the default subdue times

## Description
Add sub-second resolution to default subdue times

## Related Issue
https://github.com/sensu/sensu/issues/1964

## Motivation and Context
We run 100s of checks with subdue attributes that are pinging us when they run between `23:59:59 UTC` and `00:00:00 UTC` the next day.

## How Has This Been Tested?
Timecop, using a hacky work around in our environment

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. `I'd have to add timecop`
- [x] All new and existing tests passed.
